### PR TITLE
fix(tests/cocotb/tutorial): include generated ELF in runfiles to avoid FileNotFoundError

### DIFF
--- a/tests/cocotb/tutorial/BUILD
+++ b/tests/cocotb/tutorial/BUILD
@@ -51,10 +51,11 @@ cocotb_test_suite(
             "//coralnpu_test_utils:core_mini_axi_sim_interface",
             "@rules_python//python/runfiles",
         ],
-        "data": glob(["**/*.elf"]),
+        "data": [":coralnpu_v2_program"],
     },
     vcs_build_args = VCS_BUILD_ARGS,
-    vcs_data = glob(["**/*.elf"]) + [
+    vcs_data = [
+        ":coralnpu_v2_program",
         "//tests/cocotb:coverage_exclude.cfg",
     ],
     vcs_defines = VCS_DEFINES,


### PR DESCRIPTION
The cocotb tutorial test failed at runtime with: 

`FileNotFoundError: .../runfiles/.../tests/cocotb/tutorial/coralnpu_v2_program.elf`

because glob(["**/*.elf"]) only matches source files in the package, not generated outputs. As a result, the ELF built by the coralnpu_v2_binary rule was not added to the test’s runfiles.

Fixes #5 

## Changes

```diff
--- a/tests/cocotb/tutorial/BUILD.bazel
+++ b/tests/cocotb/tutorial/BUILD.bazel
@@ -... +...
-        "data": glob(["**/*.elf"]),
+        "data": [":coralnpu_v2_program"],
@@ -... +...
-    vcs_data = glob(["**/*.elf"]) + [
+    vcs_data = [
+        ":coralnpu_v2_program",
         "//tests/cocotb:coverage_exclude.cfg",
     ],
```


## Why

- Explicitly depending on the producing target guarantees Bazel includes the emitted ELF (`.elf`, `.bin`, `.vmem`) in the test’s runfiles. `glob()` does not capture generated artifacts.

## Results
Before
```shell
bazel build //tests/cocotb/tutorial:coralnpu_v2_program
bazel run //tests/cocotb/tutorial:tutorial
# -> FileNotFoundError for coralnpu_v2_program.elf
```

Verified after 

```shell
bazel run //tests/cocotb/tutorial:tutorial --test_output=all
# PASS
# Logs include: "I got [8994 8995 8996 8997 8998 8999 9000 9001]"
```

## Notes

- Change is scoped to runfiles staging only; test semantics unchanged.
- Consider applying the same pattern to any other tests that consume generated program images.