### PR TITLE
Fix: missing output address setting for tutorial

### DIFF
--- a/doc/tutorials/writing_coralnpu_programs.md
+++ b/doc/tutorials/writing_coralnpu_programs.md
@@ -144,6 +144,7 @@ async def core_mini_axi_tutorial(dut):
       entry_point = await core_mini_axi.load_elf(f)
 +     inputs1_addr = core_mini_axi.lookup_symbol(f, "input1_buffer")
 +     inputs2_addr = core_mini_axi.lookup_symbol(f, "input2_buffer")
++     outputs_addr = core_mini_axi.lookup_symbol(f, "output_buffer")
 
 +   input1_data = np.arange(8, dtype=np.uint32)
 +   input2_data = 8994 * np.ones(8, dtype=np.uint32)
@@ -172,6 +173,7 @@ async def core_mini_axi_tutorial(dut):
       entry_point = await core_mini_axi.load_elf(f)
       inputs1_addr = core_mini_axi.lookup_symbol(f, "input1_buffer")
       inputs2_addr = core_mini_axi.lookup_symbol(f, "input2_buffer")
+      outputs_addr = core_mini_axi.lookup_symbol(f, "output_buffer")
 
     input1_data = np.arange(8, dtype=np.uint32)
     input2_data = 8994 * np.ones(8, dtype=np.uint32)
@@ -200,6 +202,7 @@ async def core_mini_axi_tutorial(dut):
       entry_point = await core_mini_axi.load_elf(f)
       inputs1_addr = core_mini_axi.lookup_symbol(f, "input1_buffer")
       inputs2_addr = core_mini_axi.lookup_symbol(f, "input2_buffer")
+      outputs_addr = core_mini_axi.lookup_symbol(f, "output_buffer")
 
     input1_data = np.arange(8, dtype=np.uint32)
     input2_data = 8994 * np.ones(8, dtype=np.uint32)


### PR DESCRIPTION
`outputs_addr = core_mini_axi.lookup_symbol(f, "output_buffer")`

This line needs to be added for executing tutorial code.