### PR TITLE
fix: correct bitwidth in MuxLookup default value for Sram_Nx128

### DIFF
--- a/hdl/chisel/src/coralnpu/SramNx128.scala
+++ b/hdl/chisel/src/coralnpu/SramNx128.scala
@@ -71,6 +71,6 @@ class Sram_Nx128(tcmEntries: Int) extends Module {
 
   // Mux read output
   val selectedSramRead = RegNext(selectedSram, 0.U(sramSelectBits.W))
-  io.rdata := MuxLookup(selectedSramRead, 0.U(sramAddrBits.W))(
+  io.rdata := MuxLookup(selectedSramRead, 0.U(128.W))(
       (0 until nSramModules).map(i => i.U -> sramModules(i).io.rdata))
 }


### PR DESCRIPTION
Fix bitwidth mismatch in Sram_Nx128's MuxLookup by changing default value from address width (sramAddrBits.W) to 128-bit width to match io.rdata port.