### PR TITLE
Add DSim Support for UVM Testbench

### DIFF
--- a/doc/simulation.md
+++ b/doc/simulation.md
@@ -1,9 +1,10 @@
 # Simulation
 
+CoralNPU supports using either VCS simulator or DSim.
+
 ## VCS Support
 
-CoralNPU supports using VCS simulator. To enable VCS support, the following
-environment variables need to be set:
+To enable VCS support, the following environment variables need to be set:
 
 ```
 export VCS_HOME=${PATH_TO_YOUR_VCS_HOME}
@@ -33,3 +34,41 @@ vcs_testbench_test(
 
 By default, we disable VCS within bazel. Invoke
 `bazel {build,run,test} --config=vcs` to enable VCS support.
+
+## DSim Support
+
+### Prerequisites
+1. Ensure that Docker is installed and available for use.
+2. Download the DSim binary (`AltairDSim2025.0.1_linux64.bin`) into `utils/`.
+3. Place your DSim license JSON file (`dsim-license.json`) into `utils/`.
+4. Clone `coralnpu-mpact`.
+5. Set the following environment variable:
+```
+export CORALNPU_MPACT=${PATH_TO_coralnpu-mpact}
+```
+
+### Build Images
+```
+docker build --platform linux/amd64 -f utils/coralnpu-dsim.dockerfile -t coralnpu-dsim .
+```
+
+### Launch Container
+```
+docker run -it --platform linux/amd64 -v $(pwd):/workspace -w /workspace coralnpu-dsim
+```
+
+### Compile UVM Testbench
+```
+cd tests/uvm
+make compile
+```
+
+### Run Tests
+```
+cp <path to your ELF file> tests/uvm/bin
+make run TEST_ELF=./bin/<test>.elf
+```
+
+### Outputs
+- Logs: `sim_work/logs/`
+- Waves: `sim_work/waves/`

--- a/hdl/chisel/src/coralnpu/SramNx128.scala
+++ b/hdl/chisel/src/coralnpu/SramNx128.scala
@@ -18,7 +18,7 @@ import chisel3._
 import chisel3.util._
 
 class Sram_Nx128(tcmEntries: Int) extends Module {
-  override val desiredName = "SRAM_" + tcmEntries + "x128"
+  override val desiredName = "SRAM_" + tcmEntries + "x128" + "_wrapper"
   val addrBits = log2Ceil(tcmEntries)
   val io = IO(new Bundle {
     val addr = Input(UInt(addrBits.W))

--- a/tests/uvm/Makefile
+++ b/tests/uvm/Makefile
@@ -25,8 +25,18 @@ GENERATED_RTL_NAME = RvvCoreMiniVerificationAxi.sv
 GENERATED_RTL_SRC = $(BAZEL_BIN_DIR)/hdl/chisel/src/coralnpu/$(GENERATED_RTL_NAME)
 
 # User Configuration
-VCS = vcs
+SIM ?= dsim
 CXX = clang++
+
+# Detect simulator tool from SIM binary path
+SIM_BASENAME = $(shell basename $(SIM))
+ifeq ($(findstring vcs,$(SIM_BASENAME)),vcs)
+    SIMTOOL = vcs
+else ifeq ($(findstring dsim,$(SIM_BASENAME)),dsim)
+    SIMTOOL = dsim
+else
+    $(error Could not detect simulator tool. Please set SIM to a path containing 'vcs' or 'dsim')
+endif
 
 # UVM DV Directories
 COMMON_DIR = ./common
@@ -46,12 +56,18 @@ RUN_OPTS_FILE = $(MEM_FILE_DIR)/elf_run_opts.f
 # MPACT-Sim Integration Paths
 MPACT_BAZEL_BIN_DIR = $(CORALNPU_MPACT)/bazel-bin/sim/cosim
 MPACT_COSIM_LIB_NAME = coralnpu_cosim_lib_static
+MPACT_COSIM_LIB_FILE = $(MPACT_BAZEL_BIN_DIR)/lib$(MPACT_COSIM_LIB_NAME).a
 
-# File List for VCS -f option
+# File List for -f option
 FILE_LIST = ./coralnpu_dv.f
 
 # Simulation Settings
-SIM_EXEC = $(SIM_DIR)/simv
+ifeq ($(SIMTOOL),dsim)
+    DSIM_WORK = dsim_work
+    DSIM_IMAGE = image
+else ifeq ($(SIMTOOL),vcs)
+    SIM_EXEC = $(SIM_DIR)/simv
+endif
 UVM_TESTNAME ?= coralnpu_base_test
 TEST_ELF ?= $(BIN_DIR)/program.elf
 UVM_VERBOSITY ?= UVM_MEDIUM
@@ -64,44 +80,70 @@ PLUSARGS = +UVM_TESTNAME=$(UVM_TESTNAME) \
 
 # Waveform Dumping
 DUMP_WAVES = 1
-WAVE_FILE = $(WAVE_DIR)/$(UVM_TESTNAME).fsdb
-
-# VCS Options
-VCS_COMPILE_OPTS = \
-	-full64 \
-	-sverilog \
-	+define+UVM_NO_DEPRECATED \
-	-ntb_opts uvm-1.2 \
-	-debug_access+all \
-	-kdb \
-	-timescale=1ns/1ps \
-	-o $(SIM_EXEC)
-
-# Add C++ compiler/linker options for MPACT-Sim
-VCS_COMPILE_OPTS += \
-    -cpp $(CXX) \
-    -cppflags "-std=c++17" \
-    -CFLAGS "-I$(CORALNPU_MPACT)" \
-    -L$(MPACT_BAZEL_BIN_DIR) \
-    -l$(MPACT_COSIM_LIB_NAME)
-
-VCS_RUN_OPTS = \
-	$(PLUSARGS) \
-	-f $(RUN_OPTS_FILE)
-
-# Add define to COMPILE options for waveform dumping
-ifeq ($(DUMP_WAVES),1)
-VCS_COMPILE_OPTS += +define+DUMP_WAVES
-VCS_RUN_OPTS += +fsdb+all \
-                +fsdbfile+$(WAVE_FILE)
+ifeq ($(SIMTOOL),dsim)
+    WAVE_FILE = $(WAVE_DIR)/$(UVM_TESTNAME).vcd
+else ifeq ($(SIMTOOL),vcs)
+    WAVE_FILE = $(WAVE_DIR)/$(UVM_TESTNAME).fsdb
 endif
 
-# Targets
+# Simulator-specific Compilation and Run Options
+ifeq ($(SIMTOOL),dsim)
+    COMPILE_OPTS = \
+			-sv \
+			+define+UVM_NO_DEPRECATED \
+			-incdir ${UVM_HOME}/src \
+			-timescale 1ns/1ps \
+			-sv_lib ${UVM_HOME}/src/dpi/libuvm_dpi.so \
+			-uvm default \
+			-noopt
+    
+    RUN_OPTS = \
+			$(PLUSARGS) \
+			-f $(RUN_OPTS_FILE) \
+			-sv_lib ${UVM_HOME}/src/dpi/libuvm_dpi.so
+    
+    ifeq ($(DUMP_WAVES),1)
+        COMPILE_OPTS += +acc+b -waves $(WAVE_FILE)
+        RUN_OPTS += -waves $(WAVE_FILE)
+    endif
 
-.PHONY: all compile run clean dirs help build_mpact_lib gen_mem_files rtl
+else ifeq ($(SIMTOOL),vcs)
+    COMPILE_OPTS = \
+			-full64 \
+			-sverilog \
+			+define+UVM_NO_DEPRECATED \
+			-ntb_opts uvm-1.2 \
+			-debug_access+all \
+			-kdb \
+			-timescale=1ns/1ps \
+			-o $(SIM_EXEC) \
+			-cpp $(CXX) \
+			-cppflags "-std=c++17" \
+			-CFLAGS "-I$(CORALNPU_MPACT)" \
+			-L$(MPACT_BAZEL_BIN_DIR) \
+			-l$(MPACT_COSIM_LIB_NAME)
+    
+    RUN_OPTS = \
+		$(PLUSARGS) \
+		-f $(RUN_OPTS_FILE)
+    
+    ifeq ($(DUMP_WAVES),1)
+        COMPILE_OPTS += +define+DUMP_WAVES
+        RUN_OPTS += +fsdb+all +fsdbfile+$(WAVE_FILE)
+    endif
+endif
+
+.PHONY: all compile compile-dsim compile-vcs run clean dirs help build_mpact_lib gen_mem_files rtl
 
 # Default target, builds and then runs.
 all: compile run
+
+# Main compile target dispatches to tool-specific target
+ifeq ($(SIMTOOL),vcs)
+compile: $(SIM_EXEC)
+else
+compile: compile-$(SIMTOOL)
+endif
 
 # Create necessary directories
 dirs:
@@ -122,18 +164,34 @@ gen_mem_files: dirs
 rtl:
 	@echo "--- Generating DUT RTL from Chisel ---"
 	bazel build //hdl/chisel/src/coralnpu:rvv_core_mini_verification_axi_cc_library_emit_verilog
+ifeq ($(SIMTOOL),dsim)
+	@echo "--- Fixing Chisel-generated code for DSim compatibility ---"
+	sed -i \
+		-e 's/:\/\/\(.*\)/: \/\/\1/g' \
+		$(GENERATED_RTL_SRC)
+endif
 
-# Compile the design
-$(SIM_EXEC): $(FILE_LIST) dirs build_mpact_lib rtl
-	@echo "--- Compiling with VCS ---"
-	$(VCS) $(VCS_COMPILE_OPTS) -l $(LOG_DIR)/compile.log -f $(FILE_LIST) $(GENERATED_RTL_SRC)
+# DSim-specific compilation
+compile-dsim: $(FILE_LIST) dirs rtl build_mpact_lib
+	@echo "--- Compiling with dsim ---"
+	$(SIM) $(COMPILE_OPTS) -l $(LOG_DIR)/compile.log -work $(DSIM_WORK) -f $(FILE_LIST) $(GENERATED_RTL_SRC)
+	# Manual linking of the MPACT-Sim library
+	@echo "--- Linking Design and Co-sim libraries ---"
+	g++ -shared -Bsymbolic -o $(DSIM_WORK)/$(DSIM_IMAGE).so $(DSIM_WORK)/obj/*o -Wl,--whole-archive $(MPACT_COSIM_LIB_FILE) -Wl,--no-whole-archive -lstdc++
 	@echo "--- Compilation Finished ---"
 
-compile: $(SIM_EXEC)
+# VCS-specific compilation
+$(SIM_EXEC): $(FILE_LIST) dirs build_mpact_lib rtl
+	@echo "--- Compiling with VCS ---"
+	$(SIM) $(COMPILE_OPTS) -l $(LOG_DIR)/compile.log -f $(FILE_LIST) $(GENERATED_RTL_SRC)
+	@echo "--- Compilation Finished ---"
+
+compile-vcs: $(SIM_EXEC)
 
 # Run the simulation
 run: gen_mem_files
 	@echo "--- Running Simulation ---"
+	@echo "Tool:      $(SIMTOOL)"
 	@echo "Test:      $(UVM_TESTNAME)"
 	@echo "ELF File:  $(TEST_ELF)"
 	@echo "Verbosity: $(UVM_VERBOSITY)"
@@ -143,13 +201,17 @@ run: gen_mem_files
 ifeq ($(DUMP_WAVES),1)
 	@echo "Wave File: $(WAVE_FILE)"
 endif
-	./$(SIM_EXEC) $(VCS_RUN_OPTS) -l $(LOG_DIR)/$(UVM_TESTNAME).log
+ifeq ($(SIMTOOL),dsim)
+	$(SIM) -work $(DSIM_WORK) -image $(DSIM_IMAGE) $(RUN_OPTS) -l $(LOG_DIR)/$(UVM_TESTNAME).log
+else ifeq ($(SIMTOOL),vcs)
+	./$(SIM_EXEC) $(RUN_OPTS) -l $(LOG_DIR)/$(UVM_TESTNAME).log
+endif
 	@echo "--- Simulation Finished ---"
 
 # Clean up simulation files
 clean:
 	@echo "--- Cleaning Simulation Files ---"
-	rm -rf $(SIM_DIR) simv* csrc* *.log* *.key *.vpd *.fsdb ucli.key DVEfiles/ verdiLog/ novas.*
+	rm -rf $(SIM_DIR) $(DSIM_WORK) simv* csrc* *.log* *.key *.vpd *.fsdb ucli.key DVEfiles/ verdiLog/ novas.*
 	bazel clean --expunge
 	@echo "--- Cleaning MPACT-Sim Bazel cache ---"
 	cd $(CORALNPU_MPACT) && bazel clean --expunge
@@ -158,9 +220,13 @@ clean:
 help:
 	@echo "Makefile Targets:"
 	@echo "  make all              : Compiles and runs the default test (same as just 'make')."
-	@echo "  make compile          : Builds the simulator executable."
+	@echo "  make compile          : Builds the simulator executable (auto-detects VCS or DSim from SIM variable)."
+	@echo "  make compile-vcs      : Builds with VCS specifically."
+	@echo "  make compile-dsim     : Builds with DSim specifically."
 	@echo "  make run              : Runs the simulation. Compiles first if the executable is missing or source files have changed."
 	@echo "                        :   Override defaults: make run UVM_TESTNAME=<test> TEST_ELF=<path> UVM_VERBOSITY=<level>"
+	@echo "                        :   To use VCS: make run SIM=vcs"
+	@echo "                        :   To use DSim: make run SIM=dsim"
 	@echo "  make rtl              : Generates the DUT Verilog from Chisel source"
 	@echo "  make build_mpact_lib  : Only builds the MPACT-Sim C++ library"
 	@echo "  make gen_mem_files    : Only generates ITCM/DTCM and run opt files"

--- a/tests/uvm/tb/coralnpu_tb_top.sv
+++ b/tests/uvm/tb/coralnpu_tb_top.sv
@@ -244,6 +244,7 @@ module coralnpu_tb_top;
                                    tohost_written_event);
 
     // Load memories at time 0
+    #0; // Needed to prevent race condition in dsim
     if ($value$plusargs("ITCM_MEM_FILE=%s", itcm_mem_file)) begin
       `uvm_info("TB_TOP", $sformatf("Loading ITCM from %s", itcm_mem_file), UVM_LOW)
       $readmemh(itcm_mem_file, coralnpu_tb_top.u_dut.itcm.sram.sramModules_0.mem);

--- a/utils/coralnpu-dsim.dockerfile
+++ b/utils/coralnpu-dsim.dockerfile
@@ -1,0 +1,113 @@
+# Dockerfile to create a stable CoralNPU build environment
+#
+# Build command:
+# docker build -t coralnpu -f utils/coralnpu.dockerfile .
+#
+# Run command:
+# docker run -it coralnpu /bin/bash
+
+FROM debian:bookworm AS base
+
+ENV TZ=UTC
+ARG _UID=1000
+ARG _GID=1000
+ARG _USERNAME=builder
+ENV HOME=/home/${_USERNAME}
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Create a directory for dsim
+WORKDIR /root
+
+# Copy the dsim binary
+COPY utils/AltairDSim2025.0.1_linux64.bin /root/
+COPY utils/dsim-license.json /root/
+
+# Make the binary executable
+RUN chmod +x /root/AltairDSim2025.0.1_linux64.bin
+
+# Install dsim
+RUN /root/AltairDSim2025.0.1_linux64.bin -i silent -DACCEPT_EULA=YES
+
+# Remove dsim installer
+RUN rm /root/AltairDSim2025.0.1_linux64.bin
+
+# Make /root directory traversable and dsim installation accessible to all users
+RUN chmod a+rx /root && \
+    chmod -R a+rX /root/AltairDSim && \
+    chmod a+r /root/dsim-license.json
+
+# Setup dsim environment
+ENV DSIM=dsim
+ENV DSIM_HOME=/root/AltairDSim/2025
+ENV DSIM_LICENSE=/root/dsim-license.json
+ENV DSIM_LIB_PATH=${DSIM_HOME}/lib
+ENV UVM_HOME=${DSIM_HOME}/uvm/1.2/
+ENV STD_LIBS=${DSIM_HOME}/std_pkgs/lib
+ENV RADFLEX_PATH=${DSIM_HOME}/radflex
+ENV LLVM_HOME=${DSIM_HOME}/llvm_small
+ENV PATH=${LLVM_HOME}/bin:${DSIM_HOME}/bin:$PATH
+ENV LD_LIBRARY_PATH=${DSIM_HOME}/lib:${LLVM_HOME}/lib
+
+# Set CORALNPU_MPACT environment variable
+ENV CORALNPU_MPACT=../../coralnpu-mpact
+
+# Symlink libuvm_dpi.so to dsim lib path
+RUN ln -s ${UVM_HOME}/src/dpi/libuvm_dpi.so ${DSIM_LIB_PATH}/libuvm_dpi.so
+
+RUN ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime && \
+    echo "${TZ}" > /etc/timezone && \
+    echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes && \
+    apt-get update && \
+    apt-get install -y -qq \
+        apt-transport-https \
+        autoconf \
+        build-essential \
+        ca-certificates \
+        ccache \
+        clang \
+        curl \
+        default-jdk \
+        fuse3 \
+        gawk \
+        git \
+        gnupg \
+        libmpfr-dev \
+        libsqlite3-dev \
+        lsb-release \
+        python-is-python3 \
+        python3 \
+        python3-pip \
+        srecord \
+        tzdata \
+        unzip \
+        xxd \
+        zip && \
+    update-ca-certificates && \
+    curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /tmp/bazel-archive-keyring.gpg && \
+    mv /tmp/bazel-archive-keyring.gpg /usr/share/keyrings/ && \
+    echo "deb [arch=$(dpkg-architecture -q DEB_HOST_ARCH) signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
+    apt update && \
+    apt install bazel bazel-7.4.1
+
+# Install Python dependencies for UVM tests
+RUN pip3 install --no-cache-dir --break-system-packages pyelftools
+
+# Create builder user
+RUN addgroup --gid ${_GID} ${_USERNAME} && \
+    adduser \
+        --home ${HOME} \
+        --disabled-password \
+        --gecos "" \
+        --uid ${_UID} \
+        --gid ${_GID} \
+        ${_USERNAME} && \
+    chown ${_USERNAME}:${_USERNAME} ${HOME} && \
+    mkdir -p ${HOME}/.cache && \
+    chown -R ${_USERNAME}:${_USERNAME} ${HOME}/.cache
+# Work around differeing libmpfr versions between distros
+RUN ln -sf /lib/x86_64-linux-gnu/libmpfr.so.6.2.0 /lib/x86_64-linux-gnu/libmpfr.so.4
+USER ${_USERNAME}
+WORKDIR ${HOME}
+
+# Default to bash for interactive development
+CMD ["/bin/bash"]


### PR DESCRIPTION
**Summary**

This PR adds support for DSim as an alternative simulator for the CoralNPU UVM testbench, alongside the existing VCS support.

**Changes**

1. Compatibility Fixes

- Race Condition Fix (`tests/uvm/tb/coralnpu_tb_top.sv`): Resolved timing issue specific to DSim simulator
- Naming Conflict Resolution (`hdl/chisel/src/coralnpu/SramNx128.scala`): Added prefix to SRAM wrapper to prevent DSim naming conflicts
- Chisel RTL Compatibility (`tests/uvm/Makefile`): Automatic sed-based fix for syntax incompatible with DSim, which can't parse the string `://`.

2. DSim Simulator Support (`tests/uvm/Makefile`)

- Tool-specific compilation and runtime options
- Custom linking logic for MPACT-Sim co-simulation library integration with DSim

3. Documentation (`doc/simulation.md`)

- Step-by-step guide for building Docker image, launching container, and running tests
- Prerequisites and environment variable configuration

cc @akashlevy