### PR TITLE
Fix vxsat CSR update path for saturating vector instructions

### DIFF
--- a/hdl/chisel/src/coralnpu/rvv/RvvCore.scala
+++ b/hdl/chisel/src/coralnpu/rvv/RvvCore.scala
@@ -159,6 +159,11 @@ object GenerateCoreShimSource {
         |    output [1:0] trap_bits_opcode,
         |    output [24:0] trap_bits_bits,""".stripMargin
 
+    // Add vxsat backend update outputs
+    moduleInterface += """
+        |    output wr_vxsat_valid_o,
+        |    output wr_vxsat_o,""".stripMargin
+
     // Remove last comma/linebreak
     moduleInterface = moduleInterface.dropRight(1)
     moduleInterface += "\n);\n"
@@ -320,7 +325,9 @@ object GenerateCoreShimSource {
         |      .queue_capacity(queue_capacity),
         |      .rd_rob2rt_o(rd_rob2rt_o),
         |      .trap_valid_o(trap_valid),
-        |      .trap_data_o(trap_data)
+        |      .trap_data_o(trap_data),
+        |      .wr_vxsat_valid_o(wr_vxsat_valid_o),
+        |      .wr_vxsat_o(wr_vxsat_o)
         |""".stripMargin.replaceAll("GENN", instructionLanes.toString)
     coreInstantiation += "  );\n"
 
@@ -401,6 +408,10 @@ class RvvCoreWrapper(p: Parameters) extends BlackBox with HasBlackBoxInline
     val vcsr_xrm = Output(UInt(2.W))
     val vcsr_vxsat = Output(Bool())
     val vcsr_ready = Input(Bool())
+
+    // VXSAT update from backend
+    val wr_vxsat_valid_o = Output(Bool())
+    val wr_vxsat_o = Output(Bool())
 
     // TODO(derekjchow): Parameterize
     val rvv2lsu = Vec(2, Decoupled(new Rvv2Lsu(p)))
@@ -549,6 +560,7 @@ class RvvCoreShim(p: Parameters) extends Module {
   vxrm := vxrm_wdata
 
   val vxsat_wdata = MuxCase(vxsat, Seq(
+      rvvCoreWrapper.io.wr_vxsat_valid_o -> (vxsat | rvvCoreWrapper.io.wr_vxsat_o),
       rvvCoreWrapper.io.vcsr_valid -> rvvCoreWrapper.io.vcsr_vxsat,
       io.csr.vxsat_write.valid -> io.csr.vxsat_write.bits,
   ))

--- a/hdl/chisel/src/coralnpu/scalar/Decode.scala
+++ b/hdl/chisel/src/coralnpu/scalar/Decode.scala
@@ -667,7 +667,12 @@ class DispatchV2(p: Parameters) extends Dispatch(p) {
       ))
       val csr_bits_index = io.inst(0).bits.inst(31,20)
       val (csr_address, csr_address_valid) = CsrAddress.safe(csr_bits_index)
-      io.csr.valid := tryDispatch && csr.valid && csr_address_valid && (if (p.enableFloat) { io.float.get.ready } else { true.B })
+      // Stall reads of vxsat (0x009) and vcsr (0x00F) until the vector unit is
+      // idle. Only these CSRs can be modified by in-flight vector instructions
+      // (saturating arithmetic sets vxsat; vcsr contains vxsat as a bitfield).
+      val isVxsatOrVcsr = csr_bits_index === 0x009.U || csr_bits_index === 0x00F.U
+      val rvvIdleOrNotVxsat = io.rvvIdle.getOrElse(true.B) || !isVxsatOrVcsr
+      io.csr.valid := tryDispatch && csr.valid && csr_address_valid && (if (p.enableFloat) { io.float.get.ready } else { true.B }) && rvvIdleOrNotVxsat
       io.csr.bits.addr := rdAddr(i)
       io.csr.bits.index := csr_bits_index
       io.csr.bits.rs1 := rs1Addr(i)

--- a/hdl/verilog/rvv/design/RvvCore.sv
+++ b/hdl/verilog/rvv/design/RvvCore.sv
@@ -94,7 +94,11 @@ module RvvCore #(parameter N = 4,
 
   // Trap output
   output logic trap_valid_o,
-  output RVVInstruction trap_data_o
+  output RVVInstruction trap_data_o,
+
+  // VXSAT update from backend (fixes C3 bug: previously dead-end wires)
+  output logic                            wr_vxsat_valid_o,
+  output logic    [`VCSR_VXSAT_WIDTH-1:0] wr_vxsat_o
 );
   logic [N-1:0] frontend_cmd_valid;
   RVVCmd [N-1:0] frontend_cmd_data;
@@ -246,5 +250,9 @@ module RvvCore #(parameter N = 4,
       .rvv_idle(rvv_backend_idle),
       .rd_rob2rt_o(rd_rob2rt)
   );
+
+  // Connect vxsat signals to outputs (fixes C3 bug)
+  assign wr_vxsat_valid_o = wr_vxsat_valid;
+  assign wr_vxsat_o = wr_vxsat;
 
 endmodule


### PR DESCRIPTION
This issue was discovered with the aid of Voltai Active Verification.

The wr_vxsat_valid and wr_vxsat signals from rvv_backend_retire were connected to dead-end local wires in RvvCore.sv. When a saturating instruction (vsaddu, vnclip, etc.) caused overflow, the saturation flag was computed correctly but silently discarded. A subsequent `csrr rd, vxsat` would return 0 instead of 1.

This violated RISC-V Vector Extension v1.0 Section 3.5, which requires vxsat to be set when saturation occurs.

Changes:

1. RvvCore.sv: Export wr_vxsat_valid and wr_vxsat as output ports instead of leaving them as dead-end local wires.

2. RvvCore.scala: Add corresponding ports to RvvCoreWrapper and wire them through to RvvCoreShim. Update vxsat_wdata to OR in the backend's saturation flag (vxsat is sticky per RVV spec).

3. Decode.scala: Stall scalar CSR reads of vxsat (0x009) and vcsr (0x00F) until the vector unit is idle. Only these CSRs can be modified by in-flight vector instructions (saturating arithmetic sets vxsat; vcsr contains vxsat as a bitfield).

Test case (added to tests/cocotb/rvv/arithmetics/vnclip_test.cc)

    void vnclip_vxsat_check() {
      asm volatile("csrwi vxsat, 0");
      buf32[0] = 0x7FFFFFFF;  // Max int32
      buf_shift16[0] = 0;      // No shift - will saturate to int16
      const auto in_v = __riscv_vle32_v_i32m1(buf32, 1);
      const auto shift = __riscv_vle16_v_u16mf2(buf_shift16, 1);
      const auto out_v = __riscv_vnclip_wv_i16mf2(in_v, shift, 0, 1);
      __riscv_vse16_v_i16mf2(buf16, out_v, 1);
      asm volatile("csrr %0, vxsat" : "=r"(vxsat_result));
      // Before fix: vxsat_result == 0 (FAIL)
      // After fix:  vxsat_result == 1 (PASS)
    }

All existing cocotb and Verilator tests pass with this change.