### PR TITLE
Fix lost RVV traps bug

### DIFF
--- a/hdl/chisel/src/coralnpu/rvv/RvvCore.scala
+++ b/hdl/chisel/src/coralnpu/rvv/RvvCore.scala
@@ -160,7 +160,9 @@ object GenerateCoreShimSource {
         |    output trap_valid,
         |    output [31:0] trap_bits_pc,
         |    output [1:0] trap_bits_opcode,
-        |    output [24:0] trap_bits_bits,""".stripMargin
+        |    output [24:0] trap_bits_bits,
+        |    input scalarTrapValid,
+        |    output scalarTrapReady,""".stripMargin
 
     // Add vxsat backend update outputs
     moduleInterface += """
@@ -330,7 +332,9 @@ object GenerateCoreShimSource {
         |      .trap_valid_o(trap_valid),
         |      .trap_data_o(trap_data),
         |      .wr_vxsat_valid_o(wr_vxsat_valid_o),
-        |      .wr_vxsat_o(wr_vxsat_o)
+        |      .wr_vxsat_o(wr_vxsat_o),
+        |      .trap_valid_rvs2rvv(scalarTrapValid),
+        |      .trap_ready_rvv2rvs(scalarTrapReady)
         |""".stripMargin.replaceAll("GENN", instructionLanes.toString)
     coreInstantiation += "  );\n"
 
@@ -437,6 +441,9 @@ class RvvCoreWrapper(p: Parameters) extends BlackBox with HasBlackBoxInline
     val configVill = Output(Bool())
     val rvv_idle = Output(Bool())
     val queue_capacity = Output(UInt(4.W))
+
+    val scalarTrapValid = Input(Bool())
+    val scalarTrapReady = Output(Bool())
   })
   dontTouch(io.rd_rob2rt_o)
 
@@ -551,6 +558,8 @@ class RvvCoreShim(p: Parameters) extends Module {
   io.configState.bits.vill        := rvvCoreWrapper.io.configVill
   io.rvv_idle                     := rvvCoreWrapper.io.rvv_idle
   io.queue_capacity               := rvvCoreWrapper.io.queue_capacity
+  rvvCoreWrapper.io.scalarTrapValid := io.scalarTrapValid
+  io.scalarTrapReady              := rvvCoreWrapper.io.scalarTrapReady
 
   val vstart_wdata = MuxCase(vstart, Seq(
       rvvCoreWrapper.io.vcsr_valid -> rvvCoreWrapper.io.vcsr_vstart,

--- a/hdl/chisel/src/coralnpu/rvv/RvvInterface.scala
+++ b/hdl/chisel/src/coralnpu/rvv/RvvInterface.scala
@@ -87,6 +87,10 @@ class RvvCoreIO(p: Parameters) extends Bundle {
     val rvv_idle = Output(Bool())
     val queue_capacity = Output(UInt(4.W))
 
+    // Scalar trap flush handshake.
+    val scalarTrapValid = Input(Bool())
+    val scalarTrapReady = Output(Bool())
+
     // ROB to RT stage writes.
     val rd_rob2rt_o = Vec(4, new Rob2Rt(p))
 }

--- a/hdl/chisel/src/coralnpu/scalar/Lsu.scala
+++ b/hdl/chisel/src/coralnpu/scalar/Lsu.scala
@@ -898,6 +898,7 @@ class LsuV2(p: Parameters) extends Lsu(p) {
   // ==========================================================================
   // Transaction update
   val faultReg = RegInit(MakeInvalid(new LsuFault(p)))
+  opQueue.io.flush := faultReg.valid
 
   // First stage of load update: Update results based on bus read
   val loadUpdatedSlot = Mux(readFired.valid,

--- a/hdl/chisel/src/coralnpu/scalar/SCore.scala
+++ b/hdl/chisel/src/coralnpu/scalar/SCore.scala
@@ -448,6 +448,20 @@ class SCore(p: Parameters) extends Module {
     csr.io.rvv.get.vtype := io.rvvcore.get.configState.bits.vtype
     csr.io.rvv.get.vxrm := io.rvvcore.get.csr.vxrm
     csr.io.rvv.get.vxsat := io.rvvcore.get.csr.vxsat
+
+    // Scalar trap flush handshake with the RVV core. When a fault fires and
+    // the RVV core has pending operations, request a flush. The guard on
+    // !rvv_idle prevents deadlock when the ROB is empty (no entry to retire
+    // with trap_flag). The rvv_idle clear handles the edge case where the
+    // RVV core becomes idle through other means before the handshake completes.
+    val rvvTrapRequest = RegInit(false.B)
+    when (fault_manager.io.out.valid && !io.rvvcore.get.rvv_idle) {
+      rvvTrapRequest := true.B
+    }
+    when (io.rvvcore.get.scalarTrapReady || io.rvvcore.get.rvv_idle) {
+      rvvTrapRequest := false.B
+    }
+    io.rvvcore.get.scalarTrapValid := rvvTrapRequest
   }
   val isBranching = bru.map(_.io.taken.valid).reduce(_||_)
   val hasFetchedInstructions = fetch.io.inst.lanes.map(_.valid).reduce(_||_)

--- a/hdl/verilog/rvv/design/RvvCore.sv
+++ b/hdl/verilog/rvv/design/RvvCore.sv
@@ -98,7 +98,11 @@ module RvvCore #(parameter N = 4,
 
   // VXSAT update from backend (fixes C3 bug: previously dead-end wires)
   output logic                            wr_vxsat_valid_o,
-  output logic    [`VCSR_VXSAT_WIDTH-1:0] wr_vxsat_o
+  output logic    [`VCSR_VXSAT_WIDTH-1:0] wr_vxsat_o,
+
+  // Scalar trap flush handshake
+  input  logic trap_valid_rvs2rvv,
+  output logic trap_ready_rvv2rvs
 );
   logic [N-1:0] frontend_cmd_valid;
   RVVCmd [N-1:0] frontend_cmd_data;
@@ -201,13 +205,6 @@ module RvvCore #(parameter N = 4,
   // CSR Update, unused for now
   logic                            wr_vxsat_valid;
   logic    [`VCSR_VXSAT_WIDTH-1:0] wr_vxsat;
-
-  // Trap handling tie-off
-  logic  trap_valid_rvs2rvv;
-  logic  trap_ready_rvv2rvs;
-  always_comb begin
-    trap_valid_rvs2rvv = 0;
-  end
 
   // Tie-off floating point writeback until implemented.
   assign async_frd_valid = 0;

--- a/tests/cocotb/BUILD
+++ b/tests/cocotb/BUILD
@@ -573,6 +573,30 @@ coralnpu_v2_binary(
     srcs = ["vector_store_fault.cc"],
 )
 
+coralnpu_v2_binary(
+    name = "lost_trap_test",
+    srcs = ["lost_trap_test.S"],
+)
+
+cocotb_test_suite(
+    name = "lost_trap_cocotb",
+    simulators = ["verilator"],
+    testcases = ["lost_trap_test"],
+    tests_kwargs = {
+        "hdl_toplevel": "RvvCoreMiniAxi",
+        "waves": False,
+        "seed": "42",
+        "test_module": ["lost_trap_test.py"],
+        "deps": [
+            "//coralnpu_test_utils:sim_test_fixture",
+            "@bazel_tools//tools/python/runfiles",
+        ],
+        "data": [":lost_trap_test.elf"],
+        "size": "medium",
+    },
+    verilator_model = ":rvv_core_mini_axi_model",
+)
+
 cocotb_test_suite(
     name = "rvv_load_store_test",
     simulators = [

--- a/tests/cocotb/lost_trap_test.S
+++ b/tests/cocotb/lost_trap_test.S
@@ -1,0 +1,126 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lost Trap Reproduction Test
+#
+# Reproduces the LOST_TRAP bug: two back-to-back vector loads to invalid
+# addresses should each cause a trap (trap_count=2), but the missing
+# mstatus.MIE/MPIE mechanism allows the second fault to overwrite mepc
+# before the first trap handler completes, resulting in trap_count=1.
+#
+# This file defines main() and is linked with the CRT (coralnpu_v2_binary).
+# The CRT provides _start, which calls main(). On return 0, CRT calls mpause.
+
+.balign 4
+.global main
+.type main, @function
+
+main:
+    # Install our custom trap handler (overrides CRT default)
+    la   t0, trap_handler
+    csrw mtvec, t0
+
+    # Initialize trap_count to 0
+    la   t0, trap_count
+    sw   zero, 0(t0)
+
+    # Initialize last_mcause/last_mepc/last_mtval to 0
+    la   t0, last_mcause
+    sw   zero, 0(t0)
+    la   t0, last_mepc
+    sw   zero, 0(t0)
+    la   t0, last_mtval
+    sw   zero, 0(t0)
+
+    # Configure vector unit: e32, m1, vl=4
+    li   t0, 4
+    vsetvli t0, t0, e32, m1, ta, ma
+
+    # Set up both invalid addresses BEFORE either load, so the two
+    # vle32.v instructions are truly back-to-back in the pipeline.
+    # 0x90000000 and 0x90001000 are outside valid AXI range
+    # (0x20000000-0x203FFFFF), so the AXI slave returns SLVERR,
+    # causing load access faults (mcause=5).
+    lui  a0, 0x90000          # a0 = 0x90000000
+    lui  a1, 0x90001          # a1 = 0x90001000
+
+    # Two back-to-back vector loads to invalid addresses.
+    # Both will be dispatched into the LSU/vector pipeline and both
+    # will generate faults. The bug: the second fault overwrites mepc
+    # before the first trap handler runs.
+    vle32.v v1, (a0)          # Trap A: load access fault
+    vle32.v v2, (a1)          # Trap B: load access fault
+
+    # If we reach here, both traps were handled (or one was lost).
+    # Return 0 so CRT calls mpause (halts the core cleanly).
+    li   a0, 0
+    ret
+
+# Trap handler: counts traps, stores diagnostics, advances mepc past
+# the faulting instruction, and returns via mret.
+.balign 4
+.global trap_handler
+.type trap_handler, @function
+trap_handler:
+    # Save t0 via mscratch (t1 is also clobbered but not live across traps)
+    csrw mscratch, t0
+
+    # Increment trap_count
+    la   t0, trap_count
+    lw   t1, 0(t0)
+    addi t1, t1, 1
+    sw   t1, 0(t0)
+
+    # Store diagnostic info
+    csrr t1, mcause
+    la   t0, last_mcause
+    sw   t1, 0(t0)
+
+    csrr t1, mepc
+    la   t0, last_mepc
+    sw   t1, 0(t0)
+
+    csrr t1, mtval
+    la   t0, last_mtval
+    sw   t1, 0(t0)
+
+    # Advance mepc past the faulting instruction (4 bytes)
+    csrr t0, mepc
+    addi t0, t0, 4
+    csrw mepc, t0
+
+    # Restore t0
+    csrr t0, mscratch
+
+    mret
+
+# Data section (placed in DTCM by the linker script)
+.section .data
+.balign 4
+
+.global trap_count
+trap_count:
+    .word 0
+
+.global last_mcause
+last_mcause:
+    .word 0
+
+.global last_mepc
+last_mepc:
+    .word 0
+
+.global last_mtval
+last_mtval:
+    .word 0

--- a/tests/cocotb/lost_trap_test.py
+++ b/tests/cocotb/lost_trap_test.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Lost Trap Reproduction Test
+
+Reproduces the LOST_TRAP bug: two back-to-back vector loads to invalid
+addresses should each cause a trap (trap_count=2), but the missing
+mstatus.MIE/MPIE mechanism allows the second fault to overwrite mepc
+before the first trap handler completes, resulting in trap_count=1.
+
+The test asserts trap_count == 2 and will FAIL when the bug is present,
+confirming the issue.
+"""
+
+import cocotb
+import numpy as np
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+
+from bazel_tools.tools.python.runfiles import runfiles
+from coralnpu_test_utils.sim_test_fixture import Fixture
+
+
+@cocotb.test()
+async def lost_trap_test(dut):
+    """Two back-to-back vector loads to invalid addresses must each trap.
+
+    Expected: trap_count = 2 (both faults handled)
+    Buggy:    trap_count = 1 (second fault overwrites mepc, one trap lost)
+    """
+    r = runfiles.Create()
+    fixture = await Fixture.Create(dut)
+
+    elf_path = r.Rlocation("coralnpu_hw/tests/cocotb/lost_trap_test.elf")
+    await fixture.load_elf_and_lookup_symbols(
+        elf_path,
+        ["trap_count", "last_mcause", "last_mepc", "last_mtval"],
+    )
+
+    dut._log.info("Running lost trap reproduction test...")
+    dut._log.info("Two back-to-back vle32.v to invalid addresses (0x90000000, 0x90001000)")
+    dut._log.info("Expected: trap_count=2, Buggy: trap_count=1")
+
+    await fixture.core_mini_axi.execute_from(fixture.entry_point)
+
+    total_cycles = 0
+    max_cycles = 5000
+    check_interval = 500
+    halted = False
+    faulted = False
+
+    while total_cycles < max_cycles:
+        for _ in range(check_interval):
+            await ClockCycles(dut.io_aclk, 1)
+            total_cycles += 1
+            if dut.io_halted.value == 1:
+                halted = True
+                break
+            if dut.io_fault.value == 1:
+                faulted = True
+                break
+        if halted or faulted:
+            break
+
+        trap_count = (await fixture.read_word("trap_count")).view(np.uint32)[0]
+        last_mcause = (await fixture.read_word("last_mcause")).view(np.uint32)[0]
+        last_mepc = (await fixture.read_word("last_mepc")).view(np.uint32)[0]
+        dut._log.info(
+            f"[cycle {total_cycles}] halted={dut.io_halted.value} "
+            f"fault={dut.io_fault.value} trap_count={trap_count} "
+            f"last_mcause=0x{last_mcause:X} last_mepc=0x{last_mepc:08X}"
+        )
+
+    dut._log.info(f"Simulation ended at cycle {total_cycles}: halted={halted}, faulted={faulted}")
+
+    assert halted or faulted, (
+        f"Core did not halt or fault within {max_cycles} cycles. "
+        f"Core appears stuck."
+    )
+
+    trap_count = (await fixture.read_word("trap_count")).view(np.uint32)[0]
+    last_mcause = (await fixture.read_word("last_mcause")).view(np.uint32)[0]
+    last_mepc = (await fixture.read_word("last_mepc")).view(np.uint32)[0]
+    last_mtval = (await fixture.read_word("last_mtval")).view(np.uint32)[0]
+
+    dut._log.info("=" * 60)
+    dut._log.info("Lost Trap Test Results")
+    dut._log.info("=" * 60)
+    dut._log.info(f"  halted      = {halted}")
+    dut._log.info(f"  faulted     = {faulted}")
+    dut._log.info(f"  cycles      = {total_cycles}")
+    dut._log.info(f"  trap_count  = {trap_count} (expected: 2)")
+    dut._log.info(f"  last_mcause = 0x{last_mcause:08X} (5 = load access fault)")
+    dut._log.info(f"  last_mepc   = 0x{last_mepc:08X}")
+    dut._log.info(f"  last_mtval  = 0x{last_mtval:08X}")
+    dut._log.info("=" * 60)
+
+    if faulted:
+        dut._log.info("Core hit a FAULT (usage fault / unrecoverable). Not mpause halt.")
+
+    assert trap_count == 2, (
+        f"Expected trap_count=2 but got {trap_count}. "
+        f"last_mcause=0x{last_mcause:X}, last_mepc=0x{last_mepc:08X}"
+    )


### PR DESCRIPTION
This problem was discovered while testing Voltai Active Verification on the coralnpu code base. It turned out that the problem stemmed from incomplete implementation. I hope this PR will fill in that gap.

When two back-to-back vector load instructions (`vle32.v`) both target invalid memory addresses, only one trap is handled. The test expects `trap_count=2` (one fault per instruction) but gets `trap_count=1`. The second fault's CSR state (mepc/mcause/mtval) overwrites the first before its trap handler completes, effectively losing a trap.

`tests/cocotb/lost_trap_test.S` issues two consecutive `vle32.v` to addresses `0x90000000` and `0x90001000`, both outside the valid AXI range. The AXI memory model returns `SLVERR` for each, which the scalar LSU interprets as a load access fault (mcause=5). A custom trap handler increments `trap_count`, stores diagnostic CSRs (`mcause`, `mepc`, `mtval`), advances `mepc` by 4, and returns via `mret`. The test asserts `trap_count == 2`.

Before the fix: `trap_count == 1` (second fault overwrites first trap's CSRs).
After the fix: `trap_count == 2` and the core halts cleanly.

These test cases have been added to the cocotb tests.  They are specific to this bug, and should probably be generalized to exercise traps systematically.

The bug had two parts:

1. **Scalar LSU opQueue not flushed on fault.** When the first `vle32.v` faulted, the second instruction remained in the LSU's `opQueue` and was dequeued and executed after the fault cleared the slot. This caused a second AXI transaction to the invalid address, producing a second `SLVERR` that overwrote `mepc`/`mcause`/`mtval` -- the "lost trap" where the first trap's CSR state was silently corrupted by the second fault.

2. **RVV core not notified of the fault.** Both vector loads were dispatched to the RVV core before either faulted. After the opQueue flush prevented the second load from executing on the AXI bus, the RVV core's ROB still had a pending entry for the second instruction waiting for an `lsu2rvv` completion that would never arrive. The RVV core stayed non-idle (`rvv_idle` = 0), which stalled the scalar Decode stage, preventing `mpause` (or any other instruction) from being dispatched.

Per the RISC-V V extension spec (Section 3.7), when a vector instruction takes a synchronous exception, all subsequent instructions must have no architectural effect. Both the scalar and vector sides of the second instruction needed to be cancelled.

**`hdl/chisel/src/coralnpu/scalar/Lsu.scala`** (~line 901):

Added `opQueue.io.flush := faultReg.valid` after the `faultReg` declaration, using Chisel's last-connection-wins semantics to override the earlier `opQueue.io.flush := false.B`. When a fault is detected, all pending instructions in the opQueue are discarded, preventing them from executing on the AXI bus and generating spurious faults that corrupt CSRs.

The RVV backend (`rvv_backend.sv`) already had a complete trap flush mechanism (`trap_valid_rvs2rvv` / `trap_ready_rvv2rvs` / `trap_flush_rvv`) that clears ALL pipeline stages (CQ, decode, UQ, all reservation stations, all execution units, LSU FIFOs, and ROB). This mechanism was built and refined over several commits by the VeriSilicon RTL team (see commits `9b35cce`, `6ffa852`, `c073861`), but it was never integrated with the scalar core -- when `RvvCore.sv` was created as the integration wrapper, `trap_valid_rvs2rvv` was tied to zero and kept as a local signal rather than a port. The fix here is just connecting the existing plumbing.

**`hdl/verilog/rvv/design/RvvCore.sv`**: Promoted `trap_valid_rvs2rvv` and `trap_ready_rvv2rvs` from internal tied-off signals to module ports. Removed the `always_comb begin trap_valid_rvs2rvv = 0; end` tie-off.

**`hdl/chisel/src/coralnpu/rvv/RvvCore.scala`**: Added `scalarTrapValid` (input) and `scalarTrapReady` (output) to the generated Verilog wrapper interface (`GenerateCoreShimSource`), the `RvvCoreWrapper` BlackBox IO, and the `RvvCoreShim` wiring.

**`hdl/chisel/src/coralnpu/rvv/RvvInterface.scala`**: Added `scalarTrapValid` and `scalarTrapReady` to `RvvCoreIO`.

**`hdl/chisel/src/coralnpu/scalar/SCore.scala`**: Added a handshake register `rvvTrapRequest` in the RVV extension section:

- Set when `fault_manager.io.out.valid` fires and the RVV core is non-idle (`!rvv_idle`), requesting a flush of pending vector operations.
- Cleared when the RVV core acknowledges via `scalarTrapReady` or becomes idle through other means (`rvv_idle`).
- The `!rvv_idle` guard prevents asserting the trap request when the RVV ROB is empty, which would cause a deadlock (no entry to retire with `trap_flag`).

1. First `vle32.v` faults -- scalar LSU sets `faultReg`, sends `vectorFault` completion to RVV core via `lsu2rvv`, and flushes the `opQueue` (discarding the second instruction on the scalar side).
2. `FaultManager` fires, `rvvTrapRequest` is set (RVV core is non-idle).
3. On the next cycle, `lsu2rvv` is consumed. `trap_en` fires in the RVV backend (trap_valid asserted, no pending LSU, not already trapping).
4. The backend injects a synthetic trap marker into the ROB via the LSU remap path. The pending entry for the second instruction retires with `trap_flag` set (bypassing the `uop_done` check).
5. `trap_flush_rvv` fires, clearing all RVV pipeline stages. `rvv_idle` goes high.
6. `rvvTrapRequest` clears. The scalar core can now dispatch `mpause`.

All the cocotb/Verilator tests pass, including the new one I added.  I don't have VCS, so I wasn't able to run tests that depend on it.