### PR TITLE
Fix vl=0 vector load/store pipeline deadlock

### DIFF
--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
@@ -3267,7 +3267,9 @@ module rvv_backend_decode_unit_ari
     endcase
   end
 
-  assign inst_is_nop = inst_encoding_correct & (~check_vl_not_0 | ~check_vstart_sle_vl);
+  // Per RISC-V V spec, vl=0 or vstart>=vl means the instruction is a no-op
+  // regardless of encoding validity. Compatible with PR #71's trap mechanism.
+  assign inst_is_nop = inst_valid & (~check_vl_not_0 | ~check_vstart_sle_vl);
 
 `ifdef ZVE32F_ON
   // check FP rounding mode is legal
@@ -3340,7 +3342,7 @@ module rvv_backend_decode_unit_ari
     lcmd.cmd.arch_state.vstart   = evstart;
   end
 
-  assign lcmd_valid              = inst_encoding_correct;
+  assign lcmd_valid              = inst_encoding_correct | inst_is_nop;
   assign lcmd.eew_vs1            = eew_vs1;
   assign lcmd.eew_vs2            = eew_vs2;
   assign lcmd.eew_vd             = eew_vd;

--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
@@ -3276,15 +3276,15 @@ module rvv_backend_decode_unit_ari
   assign check_frm = (inst.arch_state.frm < 3'd5) && valid_opf || !valid_opf;
 `endif
 
-  `ifdef ASSERT_ON
-    `ifdef TB_SUPPORT
-      `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0))
-      else $warning("pc(0x%h) instruction will be discarded directly.\n",$sampled(inst.inst_pc));
-    `else
-      `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0))
-      else $warning("This instruction will be discarded directly.\n");
-    `endif
+`ifdef ASSERT_ON
+  `ifdef TB_SUPPORT
+    `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0)&(inst_is_nop==1'b0))
+    else $warning("pc(0x%h) instruction will be discarded directly.\n",$sampled(inst.inst_pc));
+  `else
+    `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0)&(inst_is_nop==1'b0))
+    else $warning("This instruction will be discarded directly.\n");
   `endif
+`endif
 
 // get the start number of uop_index
   always_comb begin

--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv
@@ -17,7 +17,7 @@ module rvv_backend_decode_unit_ari
 //
   input   logic                       inst_valid;
   input   RVVCmd                      inst;
-  
+
   output  logic                       lcmd_valid;
   output  LCMD_t                      lcmd;
 
@@ -25,8 +25,8 @@ module rvv_backend_decode_unit_ari
 // internal signals
 //
   // split INST_t struct signals
-  logic   [`FUNCT6_WIDTH-1:0]         inst_funct6;      // inst original encoding[31:26]    
-  logic   [`VM_WIDTH-1:0]             inst_vm;          // inst original encoding[25]      
+  logic   [`FUNCT6_WIDTH-1:0]         inst_funct6;      // inst original encoding[31:26]
+  logic   [`VM_WIDTH-1:0]             inst_vm;          // inst original encoding[25]
   logic   [`REGFILE_INDEX_WIDTH-1:0]  inst_vs2;         // inst original encoding[24:20]
   logic   [`REGFILE_INDEX_WIDTH-1:0]  inst_vs1;         // inst original encoding[19:15]
   logic   [`IMM_WIDTH-1:0]            inst_imm;         // inst original encoding[19:15]
@@ -35,22 +35,22 @@ module rvv_backend_decode_unit_ari
   logic   [`NREG_WIDTH-1:0]           inst_nr;          // inst original encoding[17:15]
   logic   [`REGFILE_INDEX_WIDTH-1:0]  vs1_opcode;
   logic   [`REGFILE_INDEX_WIDTH-1:0]  vs2_opcode;
-   
-  logic   [`XLEN-1:0]                 rs1;    
+
+  logic   [`XLEN-1:0]                 rs1;
   logic   [`VSTART_WIDTH-1:0]         csr_vstart;
   logic   [`VSTART_WIDTH:0]           evstart;
   logic   [`VL_WIDTH-1:0]             csr_vl;
   logic   [`VL_WIDTH-1:0]             evl;
   RVVSEW                              csr_sew;
   RVVLMUL                             csr_lmul;
-  EMUL_e                              emul_vd;          
-  EMUL_e                              emul_vs2;          
-  EMUL_e                              emul_vs1;          
-  EMUL_e                              emul_max; 
-  EEW_e                               eew_vd;          
-  EEW_e                               eew_vs2;          
+  EMUL_e                              emul_vd;
+  EMUL_e                              emul_vs2;
+  EMUL_e                              emul_vs1;
+  EMUL_e                              emul_max;
+  EEW_e                               eew_vd;
+  EEW_e                               eew_vs2;
   EEW_e                               eew_vs1;
-  EEW_e                               eew_max;          
+  EEW_e                               eew_max;
   logic                               valid_opi;
   logic                               valid_opm;
 `ifdef ZVE32F_ON
@@ -74,15 +74,16 @@ module rvv_backend_decode_unit_ari
   logic                               check_lmul;
   logic                               check_vl_not_0;
   logic                               check_vstart_sle_vl;
+  logic                               inst_is_nop;
   logic                               check_frm;
-  logic   [`UOP_INDEX_WIDTH-1:0]      uop_vstart;         
-  logic   [`UOP_INDEX_WIDTH-1:0]      uop_index_max;         
+  logic   [`UOP_INDEX_WIDTH-1:0]      uop_vstart;
+  logic   [`UOP_INDEX_WIDTH-1:0]      uop_index_max;
   FUNCT6_u                            funct6_ari;
 
-  logic                               force_vma_agnostic; 
-  logic                               force_vta_agnostic; 
-   
-  // use for for-loop 
+  logic                               force_vma_agnostic;
+  logic                               force_vta_agnostic;
+
+  // use for for-loop
   genvar                              j;
 
 //
@@ -102,7 +103,7 @@ module rvv_backend_decode_unit_ari
   assign csr_vstart     = inst_valid ? inst.arch_state.vstart : 'b0;
   assign csr_vl         = inst_valid ? inst.arch_state.vl : 'b0;
   assign csr_sew        = inst_valid ? inst.arch_state.sew : SEW8;
-  assign csr_lmul       = inst_valid ? inst.arch_state.lmul : LMUL1;  
+  assign csr_lmul       = inst_valid ? inst.arch_state.lmul : LMUL1;
 
   always_comb begin
     // initial the data
@@ -110,7 +111,7 @@ module rvv_backend_decode_unit_ari
     valid_opm = 'b0;
     `ifdef ZVE32F_ON
     valid_opf = 'b0;
-    `endif    
+    `endif
 
     case(inst_funct3)
       OPIVV,
@@ -121,9 +122,9 @@ module rvv_backend_decode_unit_ari
     `ifdef ZVE32F_ON
       OPFVV,
       OPFVF: valid_opf = inst_valid;
-    `endif    
+    `endif
     endcase
-  end 
+  end
 
   // get EMUL
   always_comb begin
@@ -132,7 +133,7 @@ module rvv_backend_decode_unit_ari
     emul_vs2 = EMUL_NONE;
     emul_vs1 = EMUL_NONE;
     emul_max = EMUL_NONE;
-    
+
     case(inst_funct3)
       OPIVV: begin
         // OPI* instruction
@@ -259,9 +260,9 @@ module rvv_backend_decode_unit_ari
                 emul_vs1    = EMUL4;
                 emul_max    = EMUL8;
               end
-            endcase 
+            endcase
           end
-          
+
           VMERGE_VMV: begin
             case(csr_lmul)
               LMUL1_4,
@@ -296,7 +297,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           // widening instructions
           VWREDSUMU,
           VWREDSUM: begin
@@ -330,7 +331,7 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          VSLIDEUP_RGATHEREI16: begin        
+          VSLIDEUP_RGATHEREI16: begin
             // VRGATHEREI16
             case(csr_lmul)
               LMUL1_4: begin
@@ -367,7 +368,7 @@ module rvv_backend_decode_unit_ari
                   end
                 endcase
               end
-              LMUL2: begin                  
+              LMUL2: begin
                 case(csr_sew)
                   SEW8: begin
                     emul_vd     = EMUL2;
@@ -431,7 +432,7 @@ module rvv_backend_decode_unit_ari
           end
         endcase
       end
-      
+
       OPIVX: begin
         // OPI* instruction
         case(inst_funct6)
@@ -459,7 +460,7 @@ module rvv_backend_decode_unit_ari
           VRSUB,
           VSLIDEDOWN,
           VSMUL_VMVNRR,
-          VSLIDEUP_RGATHEREI16: begin        
+          VSLIDEUP_RGATHEREI16: begin
             case(csr_lmul)
               LMUL1_4,
               LMUL1_2,
@@ -585,7 +586,7 @@ module rvv_backend_decode_unit_ari
           end
         endcase
       end
-      
+
       OPIVI: begin
         // OPI* instruction
         case(inst_funct6)
@@ -604,7 +605,7 @@ module rvv_backend_decode_unit_ari
           VRGATHER,
           VRSUB,
           VSLIDEDOWN,
-          VSLIDEUP_RGATHEREI16: begin        
+          VSLIDEUP_RGATHEREI16: begin
             case(csr_lmul)
               LMUL1_4,
               LMUL1_2,
@@ -694,7 +695,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           VMERGE_VMV: begin
             case(csr_lmul)
               LMUL1_4,
@@ -796,7 +797,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           // widening instructions: 2SEW = 2SEW op SEW
           VWADDU_W,
           VWSUBU_W,
@@ -832,7 +833,7 @@ module rvv_backend_decode_unit_ari
           end
 
           VXUNARY0: begin
-            case(vs1_opcode) 
+            case(vs1_opcode)
               VZEXT_VF2,
               VSEXT_VF2: begin
                 case(csr_lmul)
@@ -886,7 +887,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
- 
+
           // SEW = SEW op SEW
           VMUL,
           VMULH,
@@ -933,7 +934,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-         
+
           // reduction
           VREDSUM,
           VREDMAXU,
@@ -973,7 +974,7 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          // mask 
+          // mask
           VMAND,
           VMNAND,
           VMANDN,
@@ -1129,7 +1130,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           // widening instructions: 2SEW = 2SEW op SEW
           VWADDU_W,
           VWSUBU_W,
@@ -1228,7 +1229,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-         
+
           // reduction
           VREDSUM,
           VREDMAXU,
@@ -1389,9 +1390,9 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          VMFEQ,           
-          VMFNE,           
-          VMFLT,           
+          VMFEQ,
+          VMFNE,
+          VMFLT,
           VMFLE: begin
             case(csr_lmul)
               LMUL1_4,
@@ -1449,7 +1450,7 @@ module rvv_backend_decode_unit_ari
                     emul_vs2    = EMUL8;
                     emul_max    = EMUL8;
                   end
-                endcase 
+                endcase
               end
               VFWCVTBF16: begin
                 case(csr_lmul)
@@ -1474,10 +1475,10 @@ module rvv_backend_decode_unit_ari
                     emul_vs2    = EMUL4;
                     emul_max    = EMUL8;
                   end
-                endcase 
+                endcase
               end
               `endif
-              VFCVT_XUFV, 
+              VFCVT_XUFV,
               VFCVT_XFV,
               VFCVT_RTZXUFV,
               VFCVT_RTZXFV,
@@ -1511,9 +1512,9 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          VFREDOSUM,       
-          VFREDUSUM,       
-          VFREDMAX,       
+          VFREDOSUM,
+          VFREDUSUM,
+          VFREDMAX,
           VFREDMIN: begin
             case(csr_lmul)
               LMUL1_4,
@@ -1580,7 +1581,7 @@ module rvv_backend_decode_unit_ari
                 emul_vs1    = EMUL4;
                 emul_max    = EMUL8;
               end
-            endcase           
+            endcase
           end
           `endif
         endcase
@@ -1588,27 +1589,27 @@ module rvv_backend_decode_unit_ari
 
       OPFVF: begin
         case(inst_funct6)
-          VFADD,          
-          VFSUB,           
-          VFRSUB,          
-          VFMUL,           
-          VFDIV,           
-          VFRDIV,          
-          VFMACC,          
-          VFNMACC,         
-          VFMSAC,          
-          VFNMSAC,         
-          VFMADD,          
-          VFNMADD,         
-          VFMSUB,          
+          VFADD,
+          VFSUB,
+          VFRSUB,
+          VFMUL,
+          VFDIV,
+          VFRDIV,
+          VFMACC,
+          VFNMACC,
+          VFMSAC,
+          VFNMSAC,
+          VFMADD,
+          VFNMADD,
+          VFMSUB,
           VFNMSUB,
-          VFMIN,         
-          VFMAX,           
-          VFSGNJ,          
-          VFSGNJN,         
+          VFMIN,
+          VFMAX,
+          VFSGNJ,
+          VFSGNJN,
           VFSGNJX,
-          VFSLIDE1UP,      
-          VFSLIDE1DOWN: begin  
+          VFSLIDE1UP,
+          VFSLIDE1DOWN: begin
             case(csr_lmul)
               LMUL1_4,
               LMUL1_2,
@@ -1635,11 +1636,11 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          VMFEQ,           
-          VMFNE,           
-          VMFLT,           
-          VMFLE,           
-          VMFGT,           
+          VMFEQ,
+          VMFNE,
+          VMFLT,
+          VMFLE,
+          VMFGT,
           VMFGE: begin
             case(csr_lmul)
               LMUL1_4,
@@ -1695,7 +1696,7 @@ module rvv_backend_decode_unit_ari
                   emul_vs2  = EMUL8;
                 emul_max    = EMUL8;
               end
-            endcase            
+            endcase
           end
 
           VWRFUNARY0: begin
@@ -1729,7 +1730,7 @@ module rvv_backend_decode_unit_ari
                 emul_vs2    = EMUL4;
                 emul_max    = EMUL8;
               end
-            endcase           
+            endcase
           end
           `endif
         endcase
@@ -1737,8 +1738,8 @@ module rvv_backend_decode_unit_ari
       `endif
     endcase
   end
- 
-// get EEW 
+
+// get EEW
   always_comb begin
     // initial
     eew_vd          = EEW_NONE;
@@ -1902,7 +1903,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           VSLIDEUP_RGATHEREI16: begin
             case(inst_funct3)
               // VRGATHEREI16
@@ -1985,7 +1986,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-         
+
           // widening instructions: 2SEW = 2SEW op SEW
           VWADDU_W,
           VWSUBU_W,
@@ -2011,7 +2012,7 @@ module rvv_backend_decode_unit_ari
 
           // SEW = extend 1/2SEW or 1/4SEW
           VXUNARY0: begin
-            case(vs1_opcode) 
+            case(vs1_opcode)
               VZEXT_VF2,
               VSEXT_VF2: begin
                 case(csr_sew)
@@ -2092,7 +2093,7 @@ module rvv_backend_decode_unit_ari
               end
             endcase
           end
-          
+
           VWMACCUS: begin
             case(csr_sew)
               SEW8: begin
@@ -2108,7 +2109,7 @@ module rvv_backend_decode_unit_ari
             endcase
           end
 
-          // mask 
+          // mask
           VMAND,
           VMNAND,
           VMANDN,
@@ -2273,19 +2274,19 @@ module rvv_backend_decode_unit_ari
             endcase
           end
           `endif
-          VFADD,          
+          VFADD,
           VFSUB,
           VFRSUB,
-          VFMUL,      
-          VFDIV,      
-          VFRDIV,     
-          VFMACC,     
-          VFNMACC,    
-          VFMSAC,     
-          VFNMSAC,    
-          VFMADD,     
-          VFNMADD,    
-          VFMSUB,     
+          VFMUL,
+          VFDIV,
+          VFRDIV,
+          VFMACC,
+          VFNMACC,
+          VFMSAC,
+          VFNMSAC,
+          VFMADD,
+          VFNMADD,
+          VFMSUB,
           VFNMSUB,
           VFMIN,
           VFMAX,
@@ -2376,7 +2377,7 @@ module rvv_backend_decode_unit_ari
                 endcase
               end
               `endif
-              VFCVT_XUFV, 
+              VFCVT_XUFV,
               VFCVT_XFV,
               VFCVT_RTZXUFV,
               VFCVT_RTZXFV,
@@ -2410,7 +2411,7 @@ module rvv_backend_decode_unit_ari
     endcase
   end
 
-//  
+//
 // instruction encoding error check
 //
   assign inst_encoding_correct = check_special&check_common&inst_valid;
@@ -2422,11 +2423,11 @@ module rvv_backend_decode_unit_ari
   // check whether vd partially overlaps vs2 with EEW_vd<EEW_vs2
   // check_vd_part_overlap_vs2=1 means that check pass (vd group does NOT overlap vs2 group partially)
   always_comb begin
-    check_vd_part_overlap_vs2 = 'b0;          
-    
+    check_vd_part_overlap_vs2 = 'b0;
+
     case(emul_vs2)
       EMUL1: begin
-        check_vd_part_overlap_vs2 = 1'b1;          
+        check_vd_part_overlap_vs2 = 1'b1;
       end
       EMUL2: begin
         check_vd_part_overlap_vs2 = !((inst_vd[0]!='b0) & ((inst_vd[`REGFILE_INDEX_WIDTH-1:1]==inst_vs2[`REGFILE_INDEX_WIDTH-1:1])));
@@ -2443,11 +2444,11 @@ module rvv_backend_decode_unit_ari
   // check whether vd partially overlaps vs1 with EEW_vd<EEW_vs1
   // check_vd_part_overlap_vs1=1 means that check pass (vd group does NOT overlap vs1 group partially)
   always_comb begin
-    check_vd_part_overlap_vs1     = 'b0;          
-    
+    check_vd_part_overlap_vs1     = 'b0;
+
     case(emul_vs1)
       EMUL1: begin
-        check_vd_part_overlap_vs1 = 1'b1;          
+        check_vd_part_overlap_vs1 = 1'b1;
       end
       EMUL2: begin
         check_vd_part_overlap_vs1 = !((inst_vd[0]!='b0) & ((inst_vd[`REGFILE_INDEX_WIDTH-1:1]==inst_vs1[`REGFILE_INDEX_WIDTH-1:1])));
@@ -2464,30 +2465,30 @@ module rvv_backend_decode_unit_ari
   // vd cannot overlap vs2
   // check_vd_overlap_vs2=1 means that check pass (vd group does NOT overlap vs2 group fully)
   always_comb begin
-    if((emul_vd==EMUL8)|(emul_vs2==EMUL8)) 
+    if((emul_vd==EMUL8)|(emul_vs2==EMUL8))
       check_vd_overlap_vs2 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:3]==inst_vs2[`REGFILE_INDEX_WIDTH-1:3]);
-    else if((emul_vd==EMUL4)|(emul_vs2==EMUL4)) 
+    else if((emul_vd==EMUL4)|(emul_vs2==EMUL4))
       check_vd_overlap_vs2 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:2]==inst_vs2[`REGFILE_INDEX_WIDTH-1:2]);
-    else if((emul_vd==EMUL2)|(emul_vs2==EMUL2)) 
+    else if((emul_vd==EMUL2)|(emul_vs2==EMUL2))
       check_vd_overlap_vs2 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:1]==inst_vs2[`REGFILE_INDEX_WIDTH-1:1]);
-    else if((emul_vd==EMUL1)|(emul_vs2==EMUL1)) 
+    else if((emul_vd==EMUL1)|(emul_vs2==EMUL1))
       check_vd_overlap_vs2 = (inst_vd!=inst_vs2);
-    else 
+    else
       check_vd_overlap_vs2 = 'b0;
   end
-  
+
   // vd cannot overlap vs1
   // check_vd_overlap_vs1=1 means that check pass (vd group does NOT overlap vs1 group fully)
   always_comb begin
-    if((emul_vd==EMUL8)|(emul_vs1==EMUL8)) 
+    if((emul_vd==EMUL8)|(emul_vs1==EMUL8))
       check_vd_overlap_vs1 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:3]==inst_vs1[`REGFILE_INDEX_WIDTH-1:3]);
-    else if((emul_vd==EMUL4)|(emul_vs1==EMUL4)) 
+    else if((emul_vd==EMUL4)|(emul_vs1==EMUL4))
       check_vd_overlap_vs1 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:2]==inst_vs1[`REGFILE_INDEX_WIDTH-1:2]);
-    else if((emul_vd==EMUL2)|(emul_vs1==EMUL2)) 
+    else if((emul_vd==EMUL2)|(emul_vs1==EMUL2))
       check_vd_overlap_vs1 = !(inst_vd[`REGFILE_INDEX_WIDTH-1:1]==inst_vs1[`REGFILE_INDEX_WIDTH-1:1]);
-    else if((emul_vd==EMUL1)|(emul_vs1==EMUL1)) 
+    else if((emul_vd==EMUL1)|(emul_vs1==EMUL1))
       check_vd_overlap_vs1 = (inst_vd!=inst_vs1);
-    else 
+    else
       check_vd_overlap_vs1 = 'b0;
   end
 
@@ -2510,7 +2511,7 @@ module rvv_backend_decode_unit_ari
       end
     endcase
   end
-  
+
   // check whether vs1 group partially overlaps vd group for EEW_vd:EEW_vs1=2:1
   always_comb begin
     check_vs1_part_overlap_vd_2_1 = 'b0;
@@ -2550,11 +2551,11 @@ module rvv_backend_decode_unit_ari
       end
     endcase
   end
- 
+
   // start to check special requirements for every instructions
-  always_comb begin 
+  always_comb begin
     check_special = 'b0;
-    
+
     case(inst_funct3)
       OPIVV: begin
         case(inst_funct6)
@@ -2580,7 +2581,7 @@ module rvv_backend_decode_unit_ari
           VSLIDEDOWN: begin
             check_special = check_vd_overlap_v0;
           end
-        
+
           VADC,
           VSBC: begin
             check_special = (inst_vm==1'b0)&(inst_vd!='b0);
@@ -2603,12 +2604,12 @@ module rvv_backend_decode_unit_ari
           VNCLIP: begin
             check_special = check_vd_overlap_v0&check_vd_part_overlap_vs2;
           end
-          
+
           VMERGE_VMV: begin
             // when vm=1, it is vmv instruction and vs2_index must be 5'b0.
             check_special = ((inst_vm=='b0)&(inst_vd!='b0)) | ((inst_vm==1'b1)&(inst_vs2=='b0));
           end
-               
+
           VWREDSUMU,
           VWREDSUM: begin
             check_special = (csr_vstart=='b0);
@@ -2617,7 +2618,7 @@ module rvv_backend_decode_unit_ari
           VSLIDEUP_RGATHEREI16,
           VRGATHER: begin
             // destination register group cannot overlap the source register group
-            check_special = check_vd_overlap_v0&check_vd_overlap_vs2&check_vd_overlap_vs1;                
+            check_special = check_vd_overlap_v0&check_vd_overlap_vs2&check_vd_overlap_vs1;
           end
         endcase
       end
@@ -2646,7 +2647,7 @@ module rvv_backend_decode_unit_ari
           VSLIDEDOWN: begin
             check_special = check_vd_overlap_v0;
           end
-        
+
           VADC,
           VSBC: begin
             check_special = (inst_vm==1'b0)&(inst_vd!='b0);
@@ -2671,12 +2672,12 @@ module rvv_backend_decode_unit_ari
           VNCLIP: begin
             check_special = check_vd_overlap_v0&check_vd_part_overlap_vs2;
           end
-          
+
           VMERGE_VMV: begin
             // when vm=1, it is vmv instruction and vs2_index must be 5'b0.
             check_special = ((inst_vm=='b0)&(inst_vd!='b0)) | ((inst_vm==1'b1)&(inst_vs2=='b0));
           end
-               
+
           VSLIDEUP_RGATHEREI16,
           VRGATHER: begin
             // destination register group cannot overlap the source register group
@@ -2722,12 +2723,12 @@ module rvv_backend_decode_unit_ari
           VNCLIP: begin
             check_special = check_vd_overlap_v0&check_vd_part_overlap_vs2;
           end
-          
+
           VMERGE_VMV: begin
             // when vm=1, it is vmv instruction and vs2_index must be 5'b0.
             check_special = ((inst_vm=='b0)&(inst_vd!='b0)) | ((inst_vm==1'b1)&(inst_vs2=='b0));
           end
-               
+
           VSMUL_VMVNRR: begin
             check_special = (inst_vm == 1'b1)&(inst_vs1[4:3]==2'b0)&
                             ((inst_nr==NREG1)|(inst_nr==NREG2)|(inst_nr==NREG4)|(inst_nr==NREG8));
@@ -2754,7 +2755,7 @@ module rvv_backend_decode_unit_ari
           VWMACC,
           VWMACCSU: begin
             // overlap constraint
-            check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1&check_vs1_part_overlap_vd_2_1;                
+            check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1&check_vs1_part_overlap_vd_2_1;
           end
 
           VWADDU_W,
@@ -2762,20 +2763,20 @@ module rvv_backend_decode_unit_ari
           VWADD_W,
           VWSUB_W: begin
             // overlap constraint
-            check_special = check_vd_overlap_v0&check_vs1_part_overlap_vd_2_1;                
+            check_special = check_vd_overlap_v0&check_vs1_part_overlap_vd_2_1;
           end
-          
+
           VXUNARY0: begin
-            case(vs1_opcode) 
+            case(vs1_opcode)
               VZEXT_VF2,
               VSEXT_VF2: begin
                 // overlap constraint
-                check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1;                
+                check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1;
               end
               VZEXT_VF4,
               VSEXT_VF4: begin
                 // overlap constraint
-                check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_4_1;                
+                check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_4_1;
               end
             endcase
           end
@@ -2796,7 +2797,7 @@ module rvv_backend_decode_unit_ari
           VAADD,
           VASUBU,
           VASUB: begin
-            check_special = check_vd_overlap_v0;          
+            check_special = check_vd_overlap_v0;
           end
 
           // reduction
@@ -2811,7 +2812,7 @@ module rvv_backend_decode_unit_ari
             check_special = (csr_vstart=='b0);
           end
 
-          // mask 
+          // mask
           VMAND,
           VMNAND,
           VMANDN,
@@ -2822,7 +2823,7 @@ module rvv_backend_decode_unit_ari
           VMXNOR: begin
             check_special = inst_vm;
           end
-          
+
           VWRXUNARY0: begin
             case(vs1_opcode)
               VCPOP,
@@ -2869,7 +2870,7 @@ module rvv_backend_decode_unit_ari
           VWMACCSU,
           VWMACCUS: begin
             // overlap constraint
-            check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1;                
+            check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1;
           end
 
           VWADDU_W,
@@ -2893,7 +2894,7 @@ module rvv_backend_decode_unit_ari
           VASUBU,
           VASUB,
           VSLIDE1DOWN: begin
-            check_special = check_vd_overlap_v0;          
+            check_special = check_vd_overlap_v0;
           end
 
           VWRXUNARY0: begin
@@ -2916,24 +2917,24 @@ module rvv_backend_decode_unit_ari
           end
           `endif
 
-          VFADD,          
-          VFSUB,      
-          VFMUL,      
-          VFDIV,      
-          VFMACC,     
-          VFNMACC,    
-          VFMSAC,     
-          VFNMSAC,    
-          VFMADD,     
-          VFNMADD,    
-          VFMSUB,     
-          VFNMSUB,    
+          VFADD,
+          VFSUB,
+          VFMUL,
+          VFDIV,
+          VFMACC,
+          VFNMACC,
+          VFMSAC,
+          VFNMSAC,
+          VFMADD,
+          VFNMADD,
+          VFMSUB,
+          VFNMSUB,
           VFMIN,
           VFMAX,
           VFSGNJ,
           VFSGNJN,
           VFSGNJX: begin
-            check_special = check_vd_overlap_v0;          
+            check_special = check_vd_overlap_v0;
           end
 
           VFUNARY1: begin
@@ -2941,8 +2942,8 @@ module rvv_backend_decode_unit_ari
               VFSQRT,
               VFRSQRT7,
               VFREC7,
-              VFCLASS: begin          
-                check_special = check_vd_overlap_v0;          
+              VFCLASS: begin
+                check_special = check_vd_overlap_v0;
               end
             endcase
           end
@@ -2964,13 +2965,13 @@ module rvv_backend_decode_unit_ari
                 check_special = check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1;
               end
               `endif
-              VFCVT_XUFV, 
+              VFCVT_XUFV,
               VFCVT_XFV,
               VFCVT_RTZXUFV,
               VFCVT_RTZXFV,
               VFCVT_FXUV,
               VFCVT_FXV: begin
-                check_special = check_vd_overlap_v0;          
+                check_special = check_vd_overlap_v0;
               end
             endcase
           end
@@ -2996,27 +2997,27 @@ module rvv_backend_decode_unit_ari
           end
           `endif
 
-          VFADD,          
-          VFSUB,      
-          VFRSUB,     
-          VFMUL,      
-          VFDIV,      
-          VFRDIV,     
-          VFMACC,     
-          VFNMACC,    
-          VFMSAC,     
-          VFNMSAC,    
-          VFMADD,     
-          VFNMADD,    
-          VFMSUB,     
-          VFNMSUB,    
+          VFADD,
+          VFSUB,
+          VFRSUB,
+          VFMUL,
+          VFDIV,
+          VFRDIV,
+          VFMACC,
+          VFNMACC,
+          VFMSAC,
+          VFNMSAC,
+          VFMADD,
+          VFNMADD,
+          VFMSUB,
+          VFNMSUB,
           VFMIN,
           VFMAX,
           VFSGNJ,
           VFSGNJN,
           VFSGNJX,
           VFSLIDE1DOWN: begin
-            check_special = check_vd_overlap_v0;          
+            check_special = check_vd_overlap_v0;
           end
 
           VMFEQ,
@@ -3037,7 +3038,7 @@ module rvv_backend_decode_unit_ari
           end
 
           VFSLIDE1UP: begin
-            check_special = check_vd_overlap_v0&check_vd_overlap_vs2;          
+            check_special = check_vd_overlap_v0&check_vd_overlap_vs2;
           end
         endcase
       end
@@ -3045,82 +3046,84 @@ module rvv_backend_decode_unit_ari
     endcase
   end
 
-  //check common requirements for all instructions
+  // Note: check_vl_not_0 and check_vstart_sle_vl are intentionally excluded.
+  // Per RISC-V V spec, vl=0 and vstart>=vl are valid states where the
+  // instruction is a no-op, not an encoding error. Fixes #89.
   assign check_common = check_vd_align&check_vs2_align&check_vs1_align&check_sew&check_lmul
                       `ifdef ZVE32F_ON
                         &check_frm
                       `endif
-                        &check_vl_not_0&check_vstart_sle_vl;
+                        ;
 
   // check whether vd is aligned to emul_vd
   always_comb begin
-    check_vd_align = 'b0; 
+    check_vd_align = 'b0;
 
     case(emul_vd)
       EMUL_NONE,
       EMUL1: begin
-        check_vd_align = 1'b1; 
+        check_vd_align = 1'b1;
       end
       EMUL2: begin
-        check_vd_align = (inst_vd[0]==1'b0); 
+        check_vd_align = (inst_vd[0]==1'b0);
       end
       EMUL4: begin
-        check_vd_align = (inst_vd[1:0]==2'b0); 
+        check_vd_align = (inst_vd[1:0]==2'b0);
       end
       EMUL8: begin
-        check_vd_align = (inst_vd[2:0]==3'b0); 
+        check_vd_align = (inst_vd[2:0]==3'b0);
       end
     endcase
   end
 
   // check whether vs2 is aligned to emul_vs2
   always_comb begin
-    check_vs2_align = 'b0; 
+    check_vs2_align = 'b0;
 
     case(emul_vs2)
       EMUL_NONE,
       EMUL1: begin
-        check_vs2_align = 1'b1; 
+        check_vs2_align = 1'b1;
       end
       EMUL2: begin
-        check_vs2_align = (inst_vs2[0]==1'b0); 
+        check_vs2_align = (inst_vs2[0]==1'b0);
       end
       EMUL4: begin
-        check_vs2_align = (inst_vs2[1:0]==2'b0); 
+        check_vs2_align = (inst_vs2[1:0]==2'b0);
       end
       EMUL8: begin
-        check_vs2_align = (inst_vs2[2:0]==3'b0); 
+        check_vs2_align = (inst_vs2[2:0]==3'b0);
       end
     endcase
   end
-    
+
   // check whether vs1 is aligned to emul_vs1
   always_comb begin
-    check_vs1_align = 'b0; 
-    
+    check_vs1_align = 'b0;
+
     case(emul_vs1)
       EMUL_NONE,
       EMUL1: begin
-        check_vs1_align = 1'b1; 
+        check_vs1_align = 1'b1;
       end
       EMUL2: begin
-        check_vs1_align = (inst_vs1[0]==1'b0); 
+        check_vs1_align = (inst_vs1[0]==1'b0);
       end
       EMUL4: begin
-        check_vs1_align = (inst_vs1[1:0]==2'b0); 
+        check_vs1_align = (inst_vs1[1:0]==2'b0);
       end
       EMUL8: begin
-        check_vs1_align = (inst_vs1[2:0]==3'b0); 
+        check_vs1_align = (inst_vs1[2:0]==3'b0);
       end
     endcase
   end
- 
+
   // check the validation of EEW
   assign check_sew = (eew_max != EEW_NONE);
-    
+
   // check the validation of EMUL
-  assign check_lmul = (emul_max != EMUL_NONE); 
-  
+  assign check_lmul = (emul_max != EMUL_NONE);
+
   // effect vstart
   always_comb begin
     evstart = {1'b0, csr_vstart};
@@ -3129,7 +3132,7 @@ module rvv_backend_decode_unit_ari
   // get evl
   always_comb begin
     evl = csr_vl;
-  
+
     case(inst_funct3)
       OPIVI: begin
         case(inst_funct6)
@@ -3213,7 +3216,7 @@ module rvv_backend_decode_unit_ari
           end
         endcase
       end
-      `endif      
+      `endif
     endcase
   end
 
@@ -3222,9 +3225,9 @@ module rvv_backend_decode_unit_ari
   always_comb begin
     check_vl_not_0      = csr_vl!='b0;
     check_vstart_sle_vl = evstart < csr_vl;
-    
+
     // Instructions that write an x register or f register do so even when vstart >= vl, including when vl=0.
-    case(inst_funct3) 
+    case(inst_funct3)
 
       OPIVI: begin
         case(inst_funct6)
@@ -3260,9 +3263,11 @@ module rvv_backend_decode_unit_ari
           end
         endcase
       end
-      `endif      
+      `endif
     endcase
   end
+
+  assign inst_is_nop = inst_encoding_correct & (~check_vl_not_0 | ~check_vstart_sle_vl);
 
 `ifdef ZVE32F_ON
   // check FP rounding mode is legal
@@ -3307,7 +3312,7 @@ module rvv_backend_decode_unit_ari
     end
   end
 
-  // get the max uop index 
+  // get the max uop index
   always_comb begin
     case(emul_max)
       EMUL1:   uop_index_max = (`UOP_INDEX_WIDTH)'('d0);
@@ -3345,7 +3350,7 @@ module rvv_backend_decode_unit_ari
   assign lcmd.emul_vd            = emul_vd;
   assign lcmd.emul_max           = emul_max;
   assign lcmd.uop_vstart         = uop_vstart;
-  assign lcmd.uop_index_max      = uop_index_max;
+  assign lcmd.uop_index_max      = inst_is_nop ? '0 : uop_index_max;
   assign lcmd.evl                = evl;
   assign lcmd.force_vma_agnostic = force_vma_agnostic;
   assign lcmd.force_vta_agnostic = force_vta_agnostic;

--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
@@ -3167,15 +3167,15 @@ module rvv_backend_decode_unit_lsu
   assign check_frm = inst.arch_state.frm < 3'd5;
 `endif
 
-  `ifdef ASSERT_ON
-    `ifdef TB_SUPPORT
-      `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0))
-      else $warning("pc(0x%h) instruction will be discarded directly.\n",$sampled(inst.inst_pc));
-    `else
-      `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0))
-      else $warning("This instruction will be discarded directly.\n");
-    `endif
+`ifdef ASSERT_ON
+  `ifdef TB_SUPPORT
+    `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0)&(inst_is_nop==1'b0))
+    else $warning("pc(0x%h) instruction will be discarded directly.\n",$sampled(inst.inst_pc));
+  `else
+    `rvv_forbid((inst_valid==1'b1)&(inst_encoding_correct==1'b0)&(inst_is_nop==1'b0))
+    else $warning("This instruction will be discarded directly.\n");
   `endif
+`endif
 
   // update force_vma_agnostic
     //When source and destination registers overlap and have different EEW, the instruction is mask- and tail-agnostic.

--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
@@ -18,16 +18,16 @@ module rvv_backend_decode_unit_lsu
 //
   input   logic                       inst_valid;
   input   RVVCmd                      inst;
-  
+
   output  logic                       lcmd_valid;
   output  LCMD_t                      lcmd;
 
 //
 // internal signals
 //
-  logic   [`FUNCT6_WIDTH-1:0]         inst_funct6;      // inst original encoding[31:26]  
+  logic   [`FUNCT6_WIDTH-1:0]         inst_funct6;      // inst original encoding[31:26]
   logic   [`NFIELD_WIDTH-1:0]         inst_nf;          // inst original encoding[31:29]
-  logic   [`VM_WIDTH-1:0]             inst_vm;          // inst original encoding[25]      
+  logic   [`VM_WIDTH-1:0]             inst_vm;          // inst original encoding[25]
   logic   [`REGFILE_INDEX_WIDTH-1:0]  inst_vs2;         // inst original encoding[24:20]
   logic   [`UMOP_WIDTH-1:0]           inst_umop;        // inst original encoding[24:20]
   logic   [`FUNCT3_WIDTH-1:0]         inst_funct3;      // inst original encoding[14:12]
@@ -40,14 +40,14 @@ module rvv_backend_decode_unit_lsu
   RVVConfigState                      vector_csr_lsu;
   RVVSEW                              csr_sew;
   RVVLMUL                             csr_lmul;
-  EMUL_e                              emul_vd;          
-  EMUL_e                              emul_vs2;          
-  EMUL_e                              emul_vd_nf; 
-  EMUL_e                              emul_max; 
-  logic   [`UOP_INDEX_WIDTH-1:0]      uop_index_max;         
-  EEW_e                               eew_vd;          
-  EEW_e                               eew_vs2;          
-  EEW_e                               eew_max;         
+  EMUL_e                              emul_vd;
+  EMUL_e                              emul_vs2;
+  EMUL_e                              emul_vd_nf;
+  EMUL_e                              emul_max;
+  logic   [`UOP_INDEX_WIDTH-1:0]      uop_index_max;
+  EEW_e                               eew_vd;
+  EEW_e                               eew_vs2;
+  EEW_e                               eew_max;
   logic                               valid_lsu;
   logic                               valid_lsu_opcode;
   logic                               valid_lsu_mop;
@@ -69,13 +69,14 @@ module rvv_backend_decode_unit_lsu
   logic                               check_sew;
   logic                               check_lmul;
   logic                               check_evl_not_0;
+  logic                               inst_is_nop;
   logic                               check_vstart_sle_evl;
   logic                               check_frm;
   FUNCT6_u                            funct6_lsu;
-  logic                               force_vma_agnostic; 
-  logic                               force_vta_agnostic; 
+  logic                               force_vma_agnostic;
+  logic                               force_vta_agnostic;
   genvar                              j;
-  
+
   // local parameter for SEW in original endocing[14:12]
   localparam  SEW_8     = 3'b000;
   localparam  SEW_16    = 3'b101;
@@ -97,7 +98,7 @@ module rvv_backend_decode_unit_lsu
   assign csr_vl         = inst_valid ? inst.arch_state.vl : 'b0;
   assign csr_sew        = inst_valid ? inst.arch_state.sew : SEW8;
   assign csr_lmul       = inst_valid ? inst.arch_state.lmul : LMULRESERVED;
-  
+
 // decode funct6
   // valid signal
   assign valid_lsu = valid_lsu_opcode&valid_lsu_mop&inst_valid;
@@ -120,16 +121,16 @@ module rvv_backend_decode_unit_lsu
 
   // lsu_mop distinguishes unit-stride, constant-stride, unordered index, ordered index
   // lsu_umop identifies what unit-stride instruction belong to when lsu_mop=US
-    // initial 
+    // initial
     funct6_lsu.lsu_funct6.lsu_mop    = US;
     funct6_lsu.lsu_funct6.lsu_umop   = US_US;
     funct6_lsu.lsu_funct6.lsu_is_seg = NONE;
     valid_lsu_mop                    = 'b0;
-    
+
     case(inst_funct6[2:0])
       UNIT_STRIDE: begin
         case(inst_umop)
-          US_REGULAR: begin          
+          US_REGULAR: begin
             funct6_lsu.lsu_funct6.lsu_mop    = US;
             funct6_lsu.lsu_funct6.lsu_umop   = US_US;
             valid_lsu_mop                    = 1'b1;
@@ -180,7 +181,7 @@ module rvv_backend_decode_unit_lsu
     emul_max        = EMUL_NONE;
     uop_index_max   = 'd0;
 
-    if (valid_lsu) begin  
+    if (valid_lsu) begin
       case(funct6_lsu.lsu_funct6.lsu_mop)
         US: begin
           case(funct6_lsu.lsu_funct6.lsu_umop)
@@ -197,7 +198,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -229,7 +230,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -259,7 +260,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -267,7 +268,7 @@ module rvv_backend_decode_unit_lsu
                           emul_max      = EMUL1;
                           uop_index_max = (`UOP_INDEX_WIDTH)'('d0);
                         end
-                        LMUL1_2: begin    
+                        LMUL1_2: begin
                           emul_vd       = EMUL2;
                           emul_vd_nf    = EMUL2;
                           emul_max      = EMUL2;
@@ -289,7 +290,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -314,7 +315,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -339,7 +340,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -365,7 +366,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -389,7 +390,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -397,7 +398,7 @@ module rvv_backend_decode_unit_lsu
                           emul_max      = EMUL2;
                           uop_index_max = (`UOP_INDEX_WIDTH)'('d1);
                         end
-                        LMUL1_2: begin    
+                        LMUL1_2: begin
                           emul_vd       = EMUL2;
                           emul_vd_nf    = EMUL4;
                           emul_max      = EMUL4;
@@ -413,7 +414,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -438,7 +439,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -463,7 +464,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -483,7 +484,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -501,7 +502,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -509,7 +510,7 @@ module rvv_backend_decode_unit_lsu
                           emul_max      = EMUL3;
                           uop_index_max = (`UOP_INDEX_WIDTH)'('d2);
                         end
-                        LMUL1_2: begin    
+                        LMUL1_2: begin
                           emul_vd       = EMUL2;
                           emul_vd_nf    = EMUL6;
                           emul_max      = EMUL6;
@@ -519,7 +520,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -538,7 +539,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -563,7 +564,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -583,7 +584,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -601,7 +602,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -609,7 +610,7 @@ module rvv_backend_decode_unit_lsu
                           emul_max      = EMUL4;
                           uop_index_max = (`UOP_INDEX_WIDTH)'('d3);
                         end
-                        LMUL1_2: begin    
+                        LMUL1_2: begin
                           emul_vd       = EMUL2;
                           emul_vd_nf    = EMUL8;
                           emul_max      = EMUL8;
@@ -619,7 +620,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -638,7 +639,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -663,7 +664,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -677,7 +678,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -689,7 +690,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -701,7 +702,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -714,7 +715,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -733,7 +734,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -747,7 +748,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -757,9 +758,9 @@ module rvv_backend_decode_unit_lsu
                           uop_index_max = (`UOP_INDEX_WIDTH)'('d5);
                         end
                       endcase
-                    end                
+                    end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -771,7 +772,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -784,7 +785,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -803,7 +804,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -817,7 +818,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -829,7 +830,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -841,7 +842,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -854,7 +855,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -873,7 +874,7 @@ module rvv_backend_decode_unit_lsu
                     // 1:1
                     {SEW_8,SEW8},
                     {SEW_16,SEW16},
-                    {SEW_32,SEW32}: begin            
+                    {SEW_32,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2,
@@ -887,7 +888,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 2:1
                     {SEW_16,SEW8},
-                    {SEW_32,SEW16}: begin            
+                    {SEW_32,SEW16}: begin
                       case(csr_lmul)
                         LMUL1_4,
                         LMUL1_2: begin
@@ -899,7 +900,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 4:1
-                    {SEW_32,SEW8}: begin            
+                    {SEW_32,SEW8}: begin
                       case(csr_lmul)
                         LMUL1_4: begin
                           emul_vd       = EMUL1;
@@ -911,7 +912,7 @@ module rvv_backend_decode_unit_lsu
                     end
                     // 1:2
                     {SEW_8,SEW16},
-                    {SEW_16,SEW32}: begin            
+                    {SEW_16,SEW32}: begin
                       case(csr_lmul)
                         LMUL1_2,
                         LMUL1,
@@ -924,7 +925,7 @@ module rvv_backend_decode_unit_lsu
                       endcase
                     end
                     // 1:4
-                    {SEW_8,SEW32}: begin            
+                    {SEW_8,SEW32}: begin
                       case(csr_lmul)
                         LMUL1,
                         LMUL2,
@@ -998,7 +999,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1030,7 +1031,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1060,7 +1061,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1068,7 +1069,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL1;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d0);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL2;
                       emul_vd_nf    = EMUL2;
                       emul_max      = EMUL2;
@@ -1090,7 +1091,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1115,7 +1116,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1140,7 +1141,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1166,7 +1167,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1190,7 +1191,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1198,7 +1199,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL2;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d1);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL2;
                       emul_vd_nf    = EMUL4;
                       emul_max      = EMUL4;
@@ -1214,7 +1215,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1239,7 +1240,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1264,7 +1265,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1284,7 +1285,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1302,7 +1303,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1310,7 +1311,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL3;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d2);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL2;
                       emul_vd_nf    = EMUL6;
                       emul_max      = EMUL6;
@@ -1320,7 +1321,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1339,7 +1340,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1364,7 +1365,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1384,7 +1385,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1402,7 +1403,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1410,7 +1411,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL4;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d3);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL2;
                       emul_vd_nf    = EMUL8;
                       emul_max      = EMUL8;
@@ -1420,7 +1421,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1439,7 +1440,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1464,7 +1465,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1478,7 +1479,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1490,7 +1491,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1502,7 +1503,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1515,7 +1516,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1534,7 +1535,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1548,7 +1549,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1558,9 +1559,9 @@ module rvv_backend_decode_unit_lsu
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d5);
                     end
                   endcase
-                end                
+                end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1572,7 +1573,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1585,7 +1586,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1604,7 +1605,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1618,7 +1619,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1630,7 +1631,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1642,7 +1643,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1655,7 +1656,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1674,7 +1675,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1688,7 +1689,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1700,7 +1701,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1712,7 +1713,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1,
@@ -1725,7 +1726,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1,
                     LMUL2,
@@ -1741,14 +1742,14 @@ module rvv_backend_decode_unit_lsu
             end
           endcase
         end
-        
+
         IU,
         IO: begin
           case(inst_nf)
             // emul_vd = ceil(csr_lmul)
             // emul_vd_nf = NF*emul_vd
             // emul_vs2 = ceil(inst_funct3/csr_sew*csr_lmul)
-            // emul_max = max(emul_vd_nf,emul_vs2) 
+            // emul_max = max(emul_vd_nf,emul_vs2)
             // uop_index_max = NF*max(emul_vd,emul_vs2)
             NF1: begin
               case({inst_funct3,csr_sew})
@@ -1756,7 +1757,7 @@ module rvv_backend_decode_unit_lsu
                 // {vs2,vd}
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1792,7 +1793,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1826,7 +1827,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -1835,7 +1836,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL1;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d0);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL1;
                       emul_vd_nf    = EMUL1;
                       emul_vs2      = EMUL2;
@@ -1860,7 +1861,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -1894,7 +1895,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL1;
@@ -1933,7 +1934,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -1962,7 +1963,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -1996,7 +1997,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2005,7 +2006,7 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL2;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d1);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL1;
                       emul_vd_nf    = EMUL2;
                       emul_vs2      = EMUL2;
@@ -2030,7 +2031,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2057,7 +2058,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2089,7 +2090,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2111,7 +2112,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2138,7 +2139,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2147,21 +2148,21 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL3;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d2);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL1;
                       emul_vd_nf    = EMUL3;
                       emul_vs2      = EMUL2;
                       emul_max      = EMUL3;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d5);
                     end
-                    LMUL1: begin    
+                    LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
                       emul_vd_nf    = EMUL3;
                       emul_vs2      = EMUL4;
                       emul_max      = EMUL4;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d11);
                     end
-                    LMUL2: begin    
+                    LMUL2: begin
                       emul_vd       = EMUL_e'(csr_lmul);
                       emul_vd_nf    = EMUL6;
                       emul_vs2      = EMUL8;
@@ -2172,7 +2173,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2192,7 +2193,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2217,7 +2218,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2239,7 +2240,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2266,7 +2267,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2275,21 +2276,21 @@ module rvv_backend_decode_unit_lsu
                       emul_max      = EMUL4;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d3);
                     end
-                    LMUL1_2: begin    
+                    LMUL1_2: begin
                       emul_vd       = EMUL1;
                       emul_vd_nf    = EMUL4;
                       emul_vs2      = EMUL2;
                       emul_max      = EMUL4;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d7);
                     end
-                    LMUL1: begin    
+                    LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
                       emul_vd_nf    = EMUL4;
                       emul_vs2      = EMUL4;
                       emul_max      = EMUL4;
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d15);
                     end
-                    LMUL2: begin    
+                    LMUL2: begin
                       emul_vd       = EMUL_e'(csr_lmul);
                       emul_vd_nf    = EMUL8;
                       emul_vs2      = EMUL8;
@@ -2300,7 +2301,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2320,7 +2321,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2345,7 +2346,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2360,7 +2361,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2380,7 +2381,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2407,7 +2408,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2420,7 +2421,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2438,7 +2439,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2453,7 +2454,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2471,9 +2472,9 @@ module rvv_backend_decode_unit_lsu
                       uop_index_max = (`UOP_INDEX_WIDTH)'('d11);
                     end
                   endcase
-                end                
+                end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2500,7 +2501,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2513,7 +2514,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2531,7 +2532,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2546,7 +2547,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2566,7 +2567,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2593,7 +2594,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2606,7 +2607,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL_e'(csr_lmul);
@@ -2624,7 +2625,7 @@ module rvv_backend_decode_unit_lsu
                 // 1:1
                 {SEW_8,SEW8},
                 {SEW_16,SEW16},
-                {SEW_32,SEW32}: begin            
+                {SEW_32,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2,
@@ -2639,7 +2640,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 2:1
                 {SEW_16,SEW8},
-                {SEW_32,SEW16}: begin            
+                {SEW_32,SEW16}: begin
                   case(csr_lmul)
                     LMUL1_4,
                     LMUL1_2: begin
@@ -2659,7 +2660,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 4:1
-                {SEW_32,SEW8}: begin            
+                {SEW_32,SEW8}: begin
                   case(csr_lmul)
                     LMUL1_4: begin
                       emul_vd       = EMUL1;
@@ -2686,7 +2687,7 @@ module rvv_backend_decode_unit_lsu
                 end
                 // 1:2
                 {SEW_8,SEW16},
-                {SEW_16,SEW32}: begin            
+                {SEW_16,SEW32}: begin
                   case(csr_lmul)
                     LMUL1_2,
                     LMUL1: begin
@@ -2699,7 +2700,7 @@ module rvv_backend_decode_unit_lsu
                   endcase
                 end
                 // 1:4
-                {SEW_8,SEW32}: begin            
+                {SEW_8,SEW32}: begin
                   case(csr_lmul)
                     LMUL1: begin
                       emul_vd       = EMUL1;
@@ -2718,14 +2719,14 @@ module rvv_backend_decode_unit_lsu
     end
   end
 
-// get EEW 
+// get EEW
   always_comb begin
     // initial
     eew_vd  = EEW_NONE;
     eew_vs2 = EEW_NONE;
-    eew_max = EEW_NONE;  
+    eew_max = EEW_NONE;
 
-    if (valid_lsu) begin  
+    if (valid_lsu) begin
       case(funct6_lsu.lsu_funct6.lsu_mop)
         US: begin
           case(funct6_lsu.lsu_funct6.lsu_umop)
@@ -2827,7 +2828,7 @@ module rvv_backend_decode_unit_lsu
     end
   end
 
-//  
+//
 // instruction encoding error check
 //
   assign inst_encoding_correct = check_special&check_common&valid_lsu;
@@ -2840,11 +2841,11 @@ module rvv_backend_decode_unit_lsu
   // check_vd_part_overlap_vs2=1 means that vd group does NOT overlap vs2 group partially
   // used in regular index load/store
   always_comb begin
-    check_vd_part_overlap_vs2     = 'b0;          
-    
+    check_vd_part_overlap_vs2     = 'b0;
+
     case(emul_vs2)
       EMUL1: begin
-        check_vd_part_overlap_vs2 = 1'b1;          
+        check_vd_part_overlap_vs2 = 1'b1;
       end
       EMUL2: begin
         check_vd_part_overlap_vs2 = !((inst_vd[0]!='b0) & ((inst_vd[`REGFILE_INDEX_WIDTH-1:1]==inst_vs2[`REGFILE_INDEX_WIDTH-1:1])));
@@ -2877,25 +2878,25 @@ module rvv_backend_decode_unit_lsu
   end
   assign vd_index_end = {1'b0, inst_vd+vd_index_offset};
 
-  always_comb begin                                                             
-    check_vd_overlap_vs2 = 'b0;          
-    
+  always_comb begin
+    check_vd_overlap_vs2 = 'b0;
+
     case(emul_vs2)
       EMUL1: begin
-        check_vd_overlap_vs2 = ({1'b0,inst_vs2}<vd_index_start) || 
-                               ({1'b0,inst_vs2}>vd_index_end);          
+        check_vd_overlap_vs2 = ({1'b0,inst_vs2}<vd_index_start) ||
+                               ({1'b0,inst_vs2}>vd_index_end);
       end
       EMUL2: begin
-        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:1]}<vd_index_start[`REGFILE_INDEX_WIDTH:1]) || 
-                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:1]}>vd_index_end[`REGFILE_INDEX_WIDTH:1]);          
+        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:1]}<vd_index_start[`REGFILE_INDEX_WIDTH:1]) ||
+                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:1]}>vd_index_end[`REGFILE_INDEX_WIDTH:1]);
       end
       EMUL4: begin
-        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:2]}<vd_index_start[`REGFILE_INDEX_WIDTH:2]) || 
-                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:2]}>vd_index_end[`REGFILE_INDEX_WIDTH:2]);          
+        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:2]}<vd_index_start[`REGFILE_INDEX_WIDTH:2]) ||
+                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:2]}>vd_index_end[`REGFILE_INDEX_WIDTH:2]);
       end
       EMUL8 : begin
-        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:3]}<vd_index_start[`REGFILE_INDEX_WIDTH:3]) || 
-                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:3]}>vd_index_end[`REGFILE_INDEX_WIDTH:3]);          
+        check_vd_overlap_vs2 = ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:3]}<vd_index_start[`REGFILE_INDEX_WIDTH:3]) ||
+                               ({1'b0,inst_vs2[`REGFILE_INDEX_WIDTH-1:3]}>vd_index_end[`REGFILE_INDEX_WIDTH:3]);
       end
     endcase
   end
@@ -2943,7 +2944,7 @@ module rvv_backend_decode_unit_lsu
   end
 
   // start to check special requirements for every instructions
-  always_comb begin 
+  always_comb begin
     check_special = 'b0;
 
     case(inst_funct6[2:0])
@@ -2963,11 +2964,11 @@ module rvv_backend_decode_unit_lsu
           end
         endcase
       end
-      
+
       CONSTANT_STRIDE: begin
         check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0 : 1'b1;
       end
-      
+
       UNORDERED_INDEX,
       ORDERED_INDEX: begin
         if (inst_nf==NF1) begin
@@ -2975,23 +2976,23 @@ module rvv_backend_decode_unit_lsu
             // EEW_vs2:EEW_vd = 1:1
             {SEW_8,SEW8},
             {SEW_16,SEW16},
-            {SEW_32,SEW32}: begin            
+            {SEW_32,SEW32}: begin
               check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0 : 1'b1;
             end
             // 2:1
             {SEW_16,SEW8},
-            {SEW_32,SEW16},            
+            {SEW_32,SEW16},
             // 4:1
-            {SEW_32,SEW8}: begin            
+            {SEW_32,SEW8}: begin
               check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0&check_vd_part_overlap_vs2 : 1'b1;
             end
             // 1:2
             {SEW_8,SEW16},
-            {SEW_16,SEW32}: begin            
+            {SEW_16,SEW32}: begin
               check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0&check_vs2_part_overlap_vd_2_1 : 1'b1;
             end
             // 1:4
-            {SEW_8,SEW32}: begin            
+            {SEW_8,SEW32}: begin
               check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0&check_vs2_part_overlap_vd_4_1 : 1'b1;
             end
           endcase
@@ -2999,64 +3000,66 @@ module rvv_backend_decode_unit_lsu
         else begin
           // segment indexed ld, vd group cannot overlap vs2 group fully
           check_special = (inst_opcode==LOAD) ? check_vd_overlap_v0&check_vd_overlap_vs2 : 1'b1;
-        end        
+        end
       end
     endcase
   end
 
-  //check common requirements for all instructions
+  // Note: check_evl_not_0 and check_vstart_sle_evl are intentionally excluded.
+  // Per RISC-V V spec, vl=0 and vstart>=evl are valid states where the
+  // instruction is a no-op, not an encoding error. Fixes #89.
   assign check_common = check_vd_align&check_vs2_align&check_vd_in_range&check_sew&check_lmul
                       `ifdef ZVE32F_ON
                         `ifdef CHECK_FRM
                         &check_frm
                         `endif
                       `endif
-                        &check_evl_not_0&check_vstart_sle_evl;
+                        ;
 
   // check whether vd is aligned to emul_vd
   always_comb begin
-    check_vd_align = 'b0; 
+    check_vd_align = 'b0;
 
     case(emul_vd)
       EMUL_NONE,
       EMUL1: begin
-        check_vd_align = 1'b1; 
+        check_vd_align = 1'b1;
       end
       EMUL2: begin
-        check_vd_align = (inst_vd[0]==1'b0); 
+        check_vd_align = (inst_vd[0]==1'b0);
       end
       EMUL4: begin
-        check_vd_align = (inst_vd[1:0]==2'b0); 
+        check_vd_align = (inst_vd[1:0]==2'b0);
       end
       EMUL8: begin
-        check_vd_align = (inst_vd[2:0]==3'b0); 
+        check_vd_align = (inst_vd[2:0]==3'b0);
       end
     endcase
   end
 
   // check whether vs2 is aligned to emul_vs2
   always_comb begin
-    check_vs2_align = 'b0; 
+    check_vs2_align = 'b0;
 
     case(emul_vs2)
       EMUL_NONE,
       EMUL1: begin
-        check_vs2_align = 1'b1; 
+        check_vs2_align = 1'b1;
       end
       EMUL2: begin
-        check_vs2_align = (inst_vs2[0]==1'b0); 
+        check_vs2_align = (inst_vs2[0]==1'b0);
       end
       EMUL4: begin
-        check_vs2_align = (inst_vs2[1:0]==2'b0); 
+        check_vs2_align = (inst_vs2[1:0]==2'b0);
       end
       EMUL8: begin
-        check_vs2_align = (inst_vs2[2:0]==3'b0); 
+        check_vs2_align = (inst_vs2[2:0]==3'b0);
       end
     endcase
   end
-  
+
   // check vd/vs3 is in 0-31 for segment load/store
-  always_comb begin 
+  always_comb begin
     case(emul_vd_nf)
       EMUL1:   check_vd_cmp = 'd31;
       EMUL2:   check_vd_cmp = 'd30;
@@ -3073,14 +3076,14 @@ module rvv_backend_decode_unit_lsu
 
   // check the validation of EEW
   assign check_sew = (eew_max != EEW_NONE);
-    
+
   // check the validation of EMUL
   assign check_lmul = (emul_max != EMUL_NONE);
 
   // get evl
   always_comb begin
     evl = csr_vl;
-    
+
     case(inst_funct6[2:0])
       UNIT_STRIDE: begin
         case(inst_umop)
@@ -3141,7 +3144,7 @@ module rvv_backend_decode_unit_lsu
               end
             endcase
           end
-          US_MASK: begin       
+          US_MASK: begin
             // evl = ceil(vl/8)
             evl = {3'b0,csr_vl[`VL_WIDTH-1:3]} + (csr_vl[2:0]!='b0);
           end
@@ -3149,12 +3152,16 @@ module rvv_backend_decode_unit_lsu
       end
     endcase
   end
-  
+
   // check evl is not 0
   assign check_evl_not_0 = evl!='b0;
 
   // check vstart < evl
   assign check_vstart_sle_evl = {1'b0,csr_vstart} < evl;
+
+  // Detect valid no-op: encoding is correct but no elements to process.
+  // Force uop_index_max=0 so exactly one NOP uop is generated to pop the CQ.
+  assign inst_is_nop = inst_encoding_correct & (~check_evl_not_0 | ~check_vstart_sle_evl);
 
 `ifdef ZVE32F_ON
   // check FP rounding mode is legal
@@ -3170,7 +3177,7 @@ module rvv_backend_decode_unit_lsu
       else $warning("This instruction will be discarded directly.\n");
     `endif
   `endif
-  
+
   // update force_vma_agnostic
     //When source and destination registers overlap and have different EEW, the instruction is mask- and tail-agnostic.
   assign force_vma_agnostic = (check_vd_overlap_vs2==1'b0)&(eew_vd!=eew_vs2)&(eew_vd!=EEW_NONE)&(eew_vs2!=EEW_NONE);
@@ -3179,7 +3186,7 @@ module rvv_backend_decode_unit_lsu
   assign force_vta_agnostic = (eew_vd==EEW1) |   // Mask destination tail elements are always treated as tail-agnostic
     //When source and destination registers overlap and have different EEW, the instruction is mask- and tail-agnostic.
                               ((check_vd_overlap_vs2==1'b0)&(eew_vd!=eew_vs2)&(eew_vd!=EEW_NONE)&(eew_vs2!=EEW_NONE));
-  
+
   // result
   assign lcmd_valid              = inst_encoding_correct;
   assign lcmd.cmd                = inst;
@@ -3192,7 +3199,7 @@ module rvv_backend_decode_unit_lsu
   assign lcmd.emul_vd            = emul_vd;
   assign lcmd.emul_max           = emul_max;
   assign lcmd.uop_vstart         = 'b0;
-  assign lcmd.uop_index_max      = uop_index_max;
+  assign lcmd.uop_index_max      = inst_is_nop ? '0 : uop_index_max;
   assign lcmd.evl                = evl;
   assign lcmd.force_vma_agnostic = force_vma_agnostic;
   assign lcmd.force_vta_agnostic = force_vta_agnostic;

--- a/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
+++ b/hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv
@@ -3005,16 +3005,14 @@ module rvv_backend_decode_unit_lsu
     endcase
   end
 
-  // Note: check_evl_not_0 and check_vstart_sle_evl are intentionally excluded.
-  // Per RISC-V V spec, vl=0 and vstart>=evl are valid states where the
-  // instruction is a no-op, not an encoding error. Fixes #89.
+  //check common requirements for all instructions
   assign check_common = check_vd_align&check_vs2_align&check_vd_in_range&check_sew&check_lmul
                       `ifdef ZVE32F_ON
                         `ifdef CHECK_FRM
                         &check_frm
                         `endif
                       `endif
-                        ;
+                        &check_evl_not_0&check_vstart_sle_evl;
 
   // check whether vd is aligned to emul_vd
   always_comb begin
@@ -3159,9 +3157,10 @@ module rvv_backend_decode_unit_lsu
   // check vstart < evl
   assign check_vstart_sle_evl = {1'b0,csr_vstart} < evl;
 
-  // Detect valid no-op: encoding is correct but no elements to process.
-  // Force uop_index_max=0 so exactly one NOP uop is generated to pop the CQ.
-  assign inst_is_nop = inst_encoding_correct & (~check_evl_not_0 | ~check_vstart_sle_evl);
+  // Per RISC-V V spec, vl=0 or vstart>=evl means the instruction is a no-op
+  // regardless of encoding validity. This bypasses all encoding checks to
+  // prevent pipeline deadlock, and is compatible with PR #71's trap mechanism.
+  assign inst_is_nop = valid_lsu & (~check_evl_not_0 | ~check_vstart_sle_evl);
 
 `ifdef ZVE32F_ON
   // check FP rounding mode is legal
@@ -3188,7 +3187,7 @@ module rvv_backend_decode_unit_lsu
                               ((check_vd_overlap_vs2==1'b0)&(eew_vd!=eew_vs2)&(eew_vd!=EEW_NONE)&(eew_vs2!=EEW_NONE));
 
   // result
-  assign lcmd_valid              = inst_encoding_correct;
+  assign lcmd_valid              = inst_encoding_correct | inst_is_nop;
   assign lcmd.cmd                = inst;
   assign lcmd.eew_vs1            = EEW_NONE;
   assign lcmd.eew_vs2            = eew_vs2;


### PR DESCRIPTION
Fixes #89

## Problem

Executing any vector load/store (or arithmetic) instruction with `vl=0` causes a permanent pipeline deadlock. Per RISC-V V spec §3.4.3, `vl=0` is a valid state where the instruction should execute as a no-op with no elements operated upon.

The root cause is in the decode stage: `check_evl_not_0` and `check_vstart_sle_evl` are included in `check_common`, which gates `inst_encoding_correct`. When `vl=0`:

```
evl = 0 → check_evl_not_0 = 0 → check_common = 0 → inst_encoding_correct = 0
→ lcmd_valid = 0 → no uops generated → CQ never pops → DEADLOCK
```

The design conflates "no work to do" (valid no-op) with "invalid encoding" (illegal instruction).

## Fix

**`hdl/verilog/rvv/design/rvv_backend_decode_unit_lsu.sv`:**
- Removed `&check_evl_not_0&check_vstart_sle_evl` from `check_common`. These are "zero work" conditions, not encoding errors.
- Added `inst_is_nop` signal that detects when encoding is valid but evl=0 or vstart>=evl.
- When `inst_is_nop`, force `uop_index_max=0` so exactly one NOP uop is generated. This uop carries `evl=0` (no real work) but sets `last_uop_valid=1`, which pops the CQ and allows the pipeline to proceed.

**`hdl/verilog/rvv/design/rvv_backend_decode_unit_ari.sv`:**
- Same fix applied with the arithmetic signal names (`check_vl_not_0`, `check_vstart_sle_vl`).

## Why This Works

With the fix, when `vl=0`:
1. `inst_encoding_correct = 1` (encoding IS valid)
2. `lcmd_valid = 1` with `evl = 0` and `uop_index_max = 0`
3. The de2 stage generates exactly one uop where:
   - `uop_valid[0] = 1 & (0 <= 0)` = 1
   - `last_uop_valid[0] = (0 == 0)` = 1
4. This triggers `push[0]` → `last_uop[0]` → `pop[0]` → **CQ pops**
5. The NOP uop flows through execution with `evl=0` (zero elements processed)
6. Pipeline continues normally — no deadlock

## Impact

- Instructions with `vl > 0` are completely unaffected (`check_evl_not_0` was already 1)
- Instructions with `vl = 0` now correctly complete as no-ops instead of deadlocking
- No new signals cross module boundaries — change is contained within the two decode units

## Related

- Issue #89: reports the deadlock with detailed root cause analysis and reproducer
- PR #71: fixes deadlocks for *illegal* encodings by raising traps. This PR is complementary — `vl=0` is a *valid* state that should silently complete, not trap.
