### PR TITLE
Multi-head FlashAttention Kernel

### DIFF
--- a/tests/cocotb/BUILD
+++ b/tests/cocotb/BUILD
@@ -707,6 +707,52 @@ RVV_ML_OPS_TESTCASES = [
 ]
 # END_TESTCASES_FOR_rvv_ml_ops_cocotb_test
 
+# BEGIN_TESTCASES_FOR_rvv_flashattention_cocotb_test
+RVV_FLASHATTENTION_TESTCASES = [
+    "core_mini_rvv_flashattention_test",
+]
+# END_TESTCASES_FOR_rvv_flashattention_cocotb_test
+
+cocotb_test_suite(
+    name = "rvv_flashattention_cocotb_test",
+    simulators = [
+        "verilator",
+        "vcs",
+    ],
+    testcases = RVV_FLASHATTENTION_TESTCASES,
+    testcases_vname = "RVV_FLASHATTENTION_TESTCASES",
+    tests_kwargs = {
+        "hdl_toplevel": "RvvCoreMini_ITCM512KB_DTCM512KBAxi",
+        "waves": False,
+        "seed": "42",
+        "test_module": ["rvv_flashattention_cocotb_test.py"],
+        "deps": [
+            "//coralnpu_test_utils:sim_test_fixture",
+            "@bazel_tools//tools/python/runfiles",
+        ],
+        "data": [
+            "//tests/cocotb/rvv/ml_ops:rvv_flashattention_test.elf",
+            "gemma_q.npy",
+            "gemma_k.npy",
+            "gemma_v.npy",
+            "gemma_o.npy",
+        ],
+        "size": "enormous",
+    },
+    vcs_build_args = VCS_BUILD_ARGS,
+    vcs_data = [
+        "//tests/cocotb/rvv/ml_ops:rvv_flashattention_test.elf",
+        "gemma_q.npy",
+        "gemma_k.npy",
+        "gemma_v.npy",
+        "gemma_o.npy",
+    ] + VCS_COMMON_DATA,
+    vcs_defines = VCS_DEFINES,
+    vcs_test_args = VCS_TEST_ARGS,
+    vcs_verilog_sources = ["//hdl/chisel/src/coralnpu:rvv_core_mini_axi_cc_library_verilog"],
+    verilator_model = ":rvv_core_mini_itcm512kb_dtcm512kb_axi_model",
+)
+
 cocotb_test_suite(
     name = "rvv_ml_ops_cocotb_test",
     simulators = [
@@ -890,4 +936,5 @@ exports_files([
     "coverage_exclude.cfg",
     "xprop.cfg",
     "rvv_ml_ops_cocotb_test.py",
+    "rvv_flashattention_cocotb_test.py",
 ])

--- a/tests/cocotb/dump_gemma_tensors.py
+++ b/tests/cocotb/dump_gemma_tensors.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import numpy as np
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from unittest.mock import patch
+
+def extract_gemma_attention_block():
+    model_id = "google/gemma-3-270m-it"
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="cpu", torch_dtype=torch.float32)
+    
+    prompt = "The architecture of the Coral NPU is designed for"
+    inputs = tokenizer(prompt, return_tensors="pt")
+    
+    extracted_data = {}
+    original_sdpa = torch.nn.functional.scaled_dot_product_attention
+    
+    # Define interceptor hook
+    def sdpa_hook(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, **kwargs):
+        # Only want to capture the very first layer to keep it simple
+        if "q" not in extracted_data:
+            # Gemma tensors shape: (batch, num_heads, seq_len, head_dim)
+            # Batch 0, Head 0 for NPU test
+            extracted_data["q"] = query[0, 0, :, :].detach().numpy()
+            extracted_data["k"] = key[0, 0, :, :].detach().numpy()
+            extracted_data["v"] = value[0, 0, :, :].detach().numpy()
+            
+            output = original_sdpa(query, key, value, attn_mask, dropout_p, is_causal, **kwargs)
+            
+            extracted_data["o"] = output[0, 0, :, :].detach().numpy()
+            return output
+            
+        return original_sdpa(query, key, value, attn_mask, dropout_p, is_causal, **kwargs)
+
+    print("Running forward pass and intercepting Attention I/O...")
+    # Hook into the forward pass
+    with patch("torch.nn.functional.scaled_dot_product_attention", side_effect=sdpa_hook):
+        model(**inputs)
+
+    print(f"Extracted Matrix Shapes: {extracted_data['q'].shape}")
+    
+    # Save the 4 exact tensors to disk
+    np.save("gemma_q.npy", extracted_data["q"])
+    np.save("gemma_k.npy", extracted_data["k"])
+    np.save("gemma_v.npy", extracted_data["v"])
+    np.save("gemma_o.npy", extracted_data["o"])
+    print("Successfully saved exact Gemma Q, K, V, and Golden O to disk!")
+
+if __name__ == "__main__":
+    extract_gemma_attention_block()

--- a/tests/cocotb/rvv/ml_ops/BUILD
+++ b/tests/cocotb/rvv/ml_ops/BUILD
@@ -64,6 +64,12 @@ template_rule(
             "srcs": ["float_matmul_runner.cc", "rvv_float_matmul_assembly.cc"],
             "hdrs": ["//sw/utils:utils.h"],
         },
+	"rvv_flashattention_test": {
+            "srcs": ["rvv_flashattention_kernel.cc", "rvv_flashattention_runner.cc"],
+            "hdrs": ["//sw/utils:utils.h"],
+            "itcm_size_kbytes": 512,
+            "dtcm_size_kbytes": 512,
+	},
     },
 )
 
@@ -75,5 +81,6 @@ filegroup(
         ":rvv_float_matmul_assembly.elf",
         ":rvv_float_matmul.elf",
         ":rvv_float_matmul_optimized.elf",
+	":rvv_flashattention_test.elf",
     ],
 )

--- a/tests/cocotb/rvv/ml_ops/rvv_flashattention_kernel.cc
+++ b/tests/cocotb/rvv/ml_ops/rvv_flashattention_kernel.cc
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <math.h>
+#include <riscv_vector.h>
+#include <stddef.h>
+#include <stdint.h>
+
+inline vfloat32m8_t rvv_exp_f32m8(vfloat32m8_t x, size_t vl) {
+  vfloat32m8_t v_log2e = __riscv_vfmv_v_f_f32m8(1.44269504f, vl);
+  vfloat32m8_t v_ln2 = __riscv_vfmv_v_f_f32m8(0.69314718f, vl);
+  vfloat32m8_t v_one = __riscv_vfmv_v_f_f32m8(1.0f, vl);
+  vfloat32m8_t v_min = __riscv_vfmv_v_f_f32m8(-88.0f, vl);
+
+  x = __riscv_vfmax_vv_f32m8(x, v_min, vl);
+  vfloat32m8_t y = __riscv_vfmul_vv_f32m8(x, v_log2e, vl);
+  vint32m8_t i_int = __riscv_vfcvt_x_f_v_i32m8(y, vl);
+  vfloat32m8_t i_float = __riscv_vfcvt_f_x_v_f32m8(i_int, vl);
+  vfloat32m8_t i_ln2 = __riscv_vfmul_vv_f32m8(i_float, v_ln2, vl);
+  vfloat32m8_t f = __riscv_vfsub_vv_f32m8(x, i_ln2, vl);
+
+  vfloat32m8_t p;
+  vfloat32m8_t c2 = __riscv_vfmv_v_f_f32m8(0.5f, vl);
+  vfloat32m8_t c3 = __riscv_vfmv_v_f_f32m8(0.16666667f, vl);
+  p = __riscv_vfmacc_vv_f32m8(c2, f, c3, vl);
+  p = __riscv_vfmacc_vv_f32m8(v_one, f, p, vl);
+  p = __riscv_vfmacc_vv_f32m8(v_one, f, p, vl);
+
+  vint32m8_t bias = __riscv_vmv_v_x_i32m8(127, vl);
+  vint32m8_t exp_bits = __riscv_vadd_vv_i32m8(i_int, bias, vl);
+  exp_bits = __riscv_vsll_vx_i32m8(exp_bits, 23, vl);
+  vfloat32m8_t v_scale = __riscv_vreinterpret_v_i32m8_f32m8(exp_bits);
+  return __riscv_vfmul_vv_f32m8(p, v_scale, vl);
+}
+
+extern "C" void FlashAttentionRVV(const float* Q, const float* K,
+                                  const float* V, float* O, size_t num_heads,
+                                  size_t s_len, size_t dim) {
+  float scale = 1.0f / sqrtf((float)dim);
+  size_t vlmax_m1 = __riscv_vsetvlmax_e32m1();
+  size_t vl = __riscv_vsetvl_e32m8(dim);
+  auto v_zero = __riscv_vfmv_v_f_f32m1(0.0f, vlmax_m1);
+
+  size_t head_stride = s_len * dim;
+
+  // Outer loop iterating over distinct heads
+  for (size_t h = 0; h < num_heads; h++) {
+    const float* Q_head = Q + (h * head_stride);
+    const float* K_head = K + (h * head_stride);
+    const float* V_head = V + (h * head_stride);
+    float* O_head = O + (h * head_stride);
+
+    for (size_t q_idx = 0; q_idx < s_len; q_idx++) {
+      float S_buf[256];
+      const float* q_row = Q_head + (q_idx * dim);
+
+      auto q_vec = __riscv_vle32_v_f32m8(q_row, vl);
+
+      // Rapid Dot Products (Unrolled Loop)
+      size_t kv_idx = 0;
+      for (; kv_idx <= s_len - 2; kv_idx += 2) {
+        auto k_vec0 = __riscv_vle32_v_f32m8(K_head + (kv_idx * dim), vl);
+        auto k_vec1 = __riscv_vle32_v_f32m8(K_head + ((kv_idx + 1) * dim), vl);
+
+        auto vacc0 = __riscv_vfmul_vv_f32m8(q_vec, k_vec0, vl);
+        auto vacc1 = __riscv_vfmul_vv_f32m8(q_vec, k_vec1, vl);
+
+        float S0 = __riscv_vfmv_f_s_f32m1_f32(
+            __riscv_vfredusum_vs_f32m8_f32m1(vacc0, v_zero, vl));
+        float S1 = __riscv_vfmv_f_s_f32m1_f32(
+            __riscv_vfredusum_vs_f32m8_f32m1(vacc1, v_zero, vl));
+
+        S_buf[kv_idx] = S0 * scale;
+        S_buf[kv_idx + 1] = S1 * scale;
+      }
+
+      // Tail cleanup for odd lengths
+      for (; kv_idx < s_len; kv_idx++) {
+        auto k_vec = __riscv_vle32_v_f32m8(K_head + (kv_idx * dim), vl);
+        auto vacc = __riscv_vfmul_vv_f32m8(q_vec, k_vec, vl);
+        float S = __riscv_vfmv_f_s_f32m1_f32(
+            __riscv_vfredusum_vs_f32m8_f32m1(vacc, v_zero, vl));
+        S_buf[kv_idx] = S * scale;
+      }
+
+      // Vectorized Softmax
+      size_t vl_seq = __riscv_vsetvl_e32m8(s_len);
+      vfloat32m8_t v_S = __riscv_vle32_v_f32m8(S_buf, vl_seq);
+
+      vfloat32m1_t v_m_scalar = __riscv_vfredmax_vs_f32m8_f32m1(
+          v_S, __riscv_vfmv_v_f_f32m1(-INFINITY, vlmax_m1), vl_seq);
+      float m = __riscv_vfmv_f_s_f32m1_f32(v_m_scalar);
+      v_S = __riscv_vfsub_vf_f32m8(v_S, m, vl_seq);
+
+      vfloat32m8_t v_P = rvv_exp_f32m8(v_S, vl_seq);
+
+      vfloat32m1_t v_d_scalar = __riscv_vfredusum_vs_f32m8_f32m1(
+          v_P, __riscv_vfmv_v_f_f32m1(0.0f, vlmax_m1), vl_seq);
+      float d_tally = __riscv_vfmv_f_s_f32m1_f32(v_d_scalar);
+      v_P = __riscv_vfdiv_vf_f32m8(v_P, d_tally, vl_seq);
+      __riscv_vse32_v_f32m8(S_buf, v_P, vl_seq);
+
+      // Register Accumulation
+      auto v_o = __riscv_vfmv_v_f_f32m8(0.0f, vl);
+      for (size_t kv_idx = 0; kv_idx < s_len; kv_idx++) {
+        float P_val = S_buf[kv_idx];
+        if (P_val == 0.0f) continue;
+
+        auto v_v = __riscv_vle32_v_f32m8(V_head + (kv_idx * dim), vl);
+        v_o = __riscv_vfmacc_vf_f32m8(v_o, P_val, v_v, vl);
+      }
+
+      // Single final write to SRAM per row
+      __riscv_vse32_v_f32m8(O_head + (q_idx * dim), v_o, vl);
+    }
+  }
+}

--- a/tests/cocotb/rvv/ml_ops/rvv_flashattention_runner.cc
+++ b/tests/cocotb/rvv/ml_ops/rvv_flashattention_runner.cc
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/utils/utils.h"
+
+// (64 KB)
+constexpr size_t kHeads = 4;
+constexpr size_t kSeqLen = 32;
+constexpr size_t kDim = 32;
+constexpr size_t kTotalElements = kHeads * kSeqLen * kDim;
+
+float q_buf[kTotalElements] __attribute__((section(".data"), used, retain))
+__attribute__((aligned(16)));
+float k_buf[kTotalElements] __attribute__((section(".data"), used, retain))
+__attribute__((aligned(16)));
+float v_buf[kTotalElements] __attribute__((section(".data"), used, retain))
+__attribute__((aligned(16)));
+float o_buf[kTotalElements] __attribute__((section(".data"), used, retain))
+__attribute__((aligned(16)));
+
+extern "C" {
+volatile uint32_t csr_cycle_count = 0;
+}
+
+extern "C" void FlashAttentionRVV(const float* Q, const float* K,
+                                  const float* V, float* O, size_t num_heads,
+                                  size_t s_len, size_t dim);
+
+int main(int argc, char** argv) {
+  uint32_t mcontext0_write_value = 1;
+  asm volatile("csrw 0x7C0, %0" : : "r"(mcontext0_write_value));
+
+  cycle_counter_reset();
+  uint64_t start_cycles = mcycle_read();
+
+  FlashAttentionRVV(q_buf, k_buf, v_buf, o_buf, kHeads, kSeqLen, kDim);
+
+  uint64_t end_cycles = mcycle_read();
+  csr_cycle_count = static_cast<uint32_t>(end_cycles - start_cycles);
+
+  mcontext0_write_value = 0;
+  asm volatile("csrw 0x7C0, %0" : : "r"(mcontext0_write_value));
+
+  return 0;
+}

--- a/tests/cocotb/rvv_flashattention_cocotb_test.py
+++ b/tests/cocotb/rvv_flashattention_cocotb_test.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cocotb
+import numpy as np
+import sys
+import os
+
+sys.set_int_max_str_digits(100000)
+
+from coralnpu_test_utils.sim_test_fixture import Fixture
+from bazel_tools.tools.python.runfiles import runfiles
+
+def log_matmul_metrics(dut, test_name: str, cycles: int, num_heads: int, lhs_rows: int, rhs_cols: int, inner: int):
+    total_macs = num_heads * lhs_rows * rhs_cols * inner
+    cycles_per_mac = cycles / total_macs if total_macs > 0 else 0
+    banner = (f"\n{'='*60}\n PERFORMANCE METRICS: {test_name}\n{'-'*60}\n"
+              f"  Total Cycles   : {cycles:,}\n  Total MACs     : {total_macs:,}\n"
+              f"  Cycles / MAC   : {cycles_per_mac:.2f}\n{'='*60}")
+    dut._log.info(banner)
+
+def calculate_cosine_similarity(actual: np.ndarray, expected: np.ndarray) -> float:
+    dot_products = np.sum(actual * expected, axis=-1)
+    norm_actual = np.linalg.norm(actual, axis=-1)
+    norm_expected = np.linalg.norm(expected, axis=-1)
+    similarities = dot_products / (norm_actual * norm_expected + 1e-9)
+    return float(np.mean(similarities))
+
+def load_real_attention_data(num_heads: int, seq_len: int, d_model: int, dut, r):
+    q_path = r.Rlocation("coralnpu_hw/tests/cocotb/gemma_q.npy")
+    k_path = r.Rlocation("coralnpu_hw/tests/cocotb/gemma_k.npy")
+    v_path = r.Rlocation("coralnpu_hw/tests/cocotb/gemma_v.npy")
+
+    if (q_path and os.path.exists(q_path) and os.path.exists(k_path) and os.path.exists(v_path)):
+        dut._log.info("SUCCESS: Real Gemma tensors found! Calculating UNMASKED Multi-Head Golden Model...")
+
+        # Helper to safely force any .npy file into target shape
+        def safe_load_and_reshape(path):
+            raw = np.load(path).astype(np.float32)
+            target_size = num_heads * seq_len * d_model
+            # np.resize flattens the array and automatically repeats the data 
+            resized = np.resize(raw.flatten(), target_size)
+            return resized.reshape((num_heads, seq_len, d_model))
+
+        q_data = safe_load_and_reshape(q_path)
+        k_data = safe_load_and_reshape(k_path)
+        v_data = safe_load_and_reshape(v_path)
+
+        # Golden Model Math
+        scores = np.matmul(q_data, k_data.transpose(0, 2, 1)) / np.sqrt(d_model)
+        m = np.max(scores, axis=-1, keepdims=True)
+        p = np.exp(scores - m)
+        p /= np.sum(p, axis=-1, keepdims=True)
+        expected_output = np.matmul(p, v_data)
+
+        return q_data, k_data, v_data, expected_output
+    else:
+        raise FileNotFoundError("CRITICAL: Real Gemma tensors not found.")
+
+@cocotb.test()
+async def core_mini_rvv_flashattention_test(dut):
+    r = runfiles.Create()
+    
+    # The 512KB memory map shifts CSRs to 0x200000
+    fixture = await Fixture.Create(dut, csr_base_addr=0x200000)
+
+    elf_name = "rvv_flashattention_test.elf"
+    elf_path = r.Rlocation(f"coralnpu_hw/tests/cocotb/rvv/ml_ops/{elf_name}")
+
+    await fixture.load_elf_and_lookup_symbols(
+        elf_path, ["q_buf", "k_buf", "v_buf", "o_buf", "csr_cycle_count"]
+    )
+
+    num_heads_val = 4
+    seq_len_val = 32
+    d_val = 32
+
+    dut._log.info(f"Loading tensors for shape: {num_heads_val}x{seq_len_val}x{d_val}")
+    q_data, k_data, v_data, expected_output = load_real_attention_data(num_heads_val, seq_len_val, d_val, dut, r)
+
+    await fixture.core_mini_axi.reset()
+
+    await fixture.write("q_buf", q_data.flatten())
+    await fixture.write("k_buf", k_data.flatten())
+    await fixture.write("v_buf", v_data.flatten())
+    await fixture.write("o_buf", np.zeros_like(q_data).flatten())
+
+    await fixture.run_to_halt(timeout_cycles=4000000)
+
+    csr_cycle_count = (await fixture.read_word('csr_cycle_count')).view(np.uint32)[0]
+
+    log_matmul_metrics(dut, f"core_mini_rvv_flashattention_{num_heads_val}x{seq_len_val}x{d_val}", 
+                       csr_cycle_count, num_heads_val, 2 * seq_len_val, d_val, seq_len_val)
+
+    num_bytes = num_heads_val * seq_len_val * d_val * 4
+    actual_packed = await fixture.read("o_buf", num_bytes)
+    actual_output = actual_packed.view(np.float32).reshape(num_heads_val, seq_len_val, d_val)
+
+    cos_sim = calculate_cosine_similarity(actual_output, expected_output)
+    dut._log.info(f"Average Cosine Similarity to Multi-Head Golden Model: {cos_sim:.6f}")
+
+    assert cos_sim > 0.999, "Accuracy failure against model!"

--- a/tests/cocotb/rvv_ml_ops_cocotb_test.py
+++ b/tests/cocotb/rvv_ml_ops_cocotb_test.py
@@ -12,6 +12,8 @@ hardware execution matches the software reference.
 import cocotb
 import numpy as np
 import argparse
+import sys
+sys.set_int_max_str_digits(100000)
 
 from coralnpu_test_utils.sim_test_fixture import Fixture
 from bazel_tools.tools.python.runfiles import runfiles
@@ -289,3 +291,86 @@ async def core_mini_rvv_float_matmul_optimized_c_test(dut):
                                    output_matmul_result,
                                    rtol=1e-4,
                                    atol=1e-4)
+def golden_flash_attention(q, k, v):
+    """NumPy Golden Reference for FlashAttention."""
+    # S = Q * K^T
+    d = q.shape[-1]
+    scores = np.matmul(q, k.T) / np.sqrt(d)
+    # Safe Softmax
+    m = np.max(scores, axis=-1, keepdims=True)
+    p = np.exp(scores - m)
+    p /= np.sum(p, axis=-1, keepdims=True)
+    # O = P * V
+    return np.matmul(p, v)
+
+@cocotb.test()
+async def core_mini_rvv_flashattention_test(dut):
+    """
+    Injects the FlashAttention RVV kernel into the Coral NPU, 
+    feeds it test matrices, and verifies the output.
+    """
+    r = runfiles.Create()
+    fixture = await Fixture.Create(dut)
+    rng = np.random.default_rng(seed=42)
+
+    # 1. THE INJECTION: Locate and load the compiled C++ ELF binary
+    elf_name = "rvv_flashattention_test.elf"
+    elf_path = r.Rlocation(f"coralnpu_hw/tests/cocotb/rvv/ml_ops/{elf_name}")
+    
+    await fixture.load_elf_and_lookup_symbols(
+        elf_path, 
+        ["q_buf", "k_buf", "v_buf", "o_buf", "csr_cycle_count"]
+    )
+    # 2. DATA GENERATION: Define dimensions
+    seq_len_val = 32
+    d_val = 32
+    
+    # Generate test data (scaled between -1 and 1 to prevent massive exponentials)
+    q_data = rng.uniform(-1, 1, (seq_len_val, d_val)).astype(np.float32)
+    k_data = rng.uniform(-1, 1, (seq_len_val, d_val)).astype(np.float32)
+    v_data = rng.uniform(-1, 1, (seq_len_val, d_val)).astype(np.float32)
+
+    # 1. HOLD IN RESET
+    await fixture.core_mini_axi.reset()
+
+    # 3. WRITE MATRICES
+    await fixture.write("q_buf", q_data.flatten())
+    await fixture.write("k_buf", k_data.flatten())
+    await fixture.write("v_buf", v_data.flatten())
+    await fixture.write("o_buf", np.zeros_like(q_data).flatten())
+
+    # 4. UNPAUSE AND EXECUTE
+    await fixture.run_to_halt(timeout_cycles=2000000)
+    
+    csr_cycle_count = (await fixture.read_word('csr_cycle_count')).view(np.uint32)[0]
+
+    log_matmul_metrics(
+        dut,
+        f"core_mini_rvv_flashattention_{seq_len_val}x{d_val}",
+        csr_cycle_count,
+        lhs_rows=2 * seq_len_val,
+        rhs_cols=d_val,
+        inner=seq_len_val
+    )
+
+    # 5. READBACK & VERIFICATION
+    num_bytes = seq_len_val * d_val * 4 # 4 bytes per FP32
+    actual_packed = await fixture.read("o_buf", num_bytes)
+    actual_output = actual_packed.view(np.float32).reshape(seq_len_val, d_val)
+
+    expected_output = golden_flash_attention(q_data, k_data, v_data)
+    
+    debug_msg = (
+        f"Flash Attention mismatch!\n"
+        f"Expected (first row): {expected_output[0][:4]}...\n"
+        f"Actual (first row):   {actual_output[0][:4]}..."
+    )
+    
+    # Assert with a slight tolerance due to the software exponential approximation
+    np.testing.assert_allclose(
+        actual_output, 
+        expected_output, 
+        rtol=1e-3, 
+        atol=1e-3, 
+        err_msg=debug_msg
+    )


### PR DESCRIPTION
brief notes on some of the files to help modification if necessary:

dump_gemma_tensors.py - used to generate data extracted from gemma 3 270m
 - note: I did not hook the output from the model too, since then it would require computing the full attention layer (which is a lot of time), instead using the NumPy golden model to test a subset of the extracted real attention matrix.
 

 rvv_flashattention_kernel.cc - main kernel file:
- note: did not implement causal mask. Not sure how you want it implemented so I left it without one.

rvv_flashattention_runner.cc - runner wrapper
- note: hardcoded to 32x32x4

BUILD - modified to use 512KB model for my test... is this okay?
rvv_core_mini_itcm512kb_dtcm512kb_axi_model

Performance Analysis for 32x32x4:
Total Cycles   : 872,075
Total MACs     : 262,144
Cycles / MAC   : 3.33

For reference, the simulation time we tested earlier today (around 780k ns at the start), it is at ~1M with 4x the calculations, so around 250k ns per head.

Let me know if this works and if any additional work needs to be done. Have a great weekend!
-Bangyan