### PR TITLE
Fix UVM regression denylist entry

### DIFF
--- a/utils/BUILD
+++ b/utils/BUILD
@@ -14,9 +14,22 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@coralnpu_hw//third_party/python:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 py_binary(
     name = "scm_info",
     srcs = ["scm_info.py"],
+)
+
+py_test(
+    name = "run_uvm_regression_test",
+    srcs = [
+        "run_uvm_regression.py",
+        "run_uvm_regression_test.py",
+    ],
+    main = "run_uvm_regression_test.py",
+    deps = [
+        requirement("pyelftools"),
+    ],
 )

--- a/utils/run_uvm_regression.py
+++ b/utils/run_uvm_regression.py
@@ -72,7 +72,7 @@ DENYLIST = [
     "//tests/cocotb/rvv/arithmetics:vfrdiv_vf_test_rtz",
     "//tests/cocotb/rvv/arithmetics:vfrdiv_vf_test_rup",
     # Exclude until MPACT supports the vector bf16 spec.
-    "//tests/cocotb:zvfbf_test"
+    "//tests/cocotb:zvfbf_test",
     # Exclude all ml_ops tests from regression
     "//tests/cocotb/rvv/ml_ops:rvv_float_matmul",
     "//tests/cocotb/rvv/ml_ops:rvv_float_matmul_assembly",

--- a/utils/run_uvm_regression_test.py
+++ b/utils/run_uvm_regression_test.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fnmatch
+import unittest
+
+from utils import run_uvm_regression
+
+
+class RunUvmRegressionTest(unittest.TestCase):
+
+    def test_zvfbf_and_first_ml_ops_targets_are_denylisted(self):
+        denylist = run_uvm_regression.DENYLIST
+
+        self.assertIn("//tests/cocotb:zvfbf_test", denylist)
+        self.assertIn("//tests/cocotb/rvv/ml_ops:rvv_float_matmul", denylist)
+        self.assertTrue(
+            any(
+                fnmatch.fnmatch("//tests/cocotb:zvfbf_test", pattern)
+                for pattern in denylist
+            )
+        )
+        self.assertTrue(
+            any(
+                fnmatch.fnmatch(
+                    "//tests/cocotb/rvv/ml_ops:rvv_float_matmul", pattern
+                )
+                for pattern in denylist
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix a missing comma in the UVM regression `DENYLIST` after
`//tests/cocotb:zvfbf_test`.

Without the separator, Python concatenates that entry with the first ml_ops
target, so neither target is denied as intended. Add a small unit test for the
two entries.

Tested:
- bazel test //utils:run_uvm_regression_test
