### PR TITLE
Fix vsetvl VL CSR readback

### DIFF
--- a/hdl/chisel/src/coralnpu/scalar/Csr.scala
+++ b/hdl/chisel/src/coralnpu/scalar/Csr.scala
@@ -22,7 +22,7 @@ import coralnpu.float.{CsrFloatIO}
 class CsrRvvIO(p: Parameters) extends Bundle {
   // To Csr from RvvCore
   val vstart = Input(UInt(log2Ceil(p.rvvVlen).W))
-  val vl = Input(UInt(log2Ceil(p.rvvVlen).W))
+  val vl = Input(UInt(log2Ceil(p.rvvVlen + 1).W))
   val vtype = Input(UInt(32.W))
   val vxrm = Input(UInt(2.W))
   val vxsat = Input(Bool())

--- a/tests/cocotb/rvv_assembly_cocotb_test.py
+++ b/tests/cocotb/rvv_assembly_cocotb_test.py
@@ -629,7 +629,7 @@ async def vsetvl_test(dut):
             await fixture.run_to_halt()
 
             actual_vl1 = (await fixture.read_word('vl_out1')).view(np.uint32)
-            actual_vl2 = (await fixture.read_word('vl_out1')).view(np.uint32)
+            actual_vl2 = (await fixture.read_word('vl_out2')).view(np.uint32)
             actual_vtype = (await fixture.read_word('vtype_out')).view(np.uint32)
 
             assert(actual_vl1 == expected_vl)


### PR DESCRIPTION
Fix the `vl` CSR readback after `vsetvl` when the configured VL equals VLEN.

`RvvInterface` carries `vl` with `log2Ceil(rvvVlen + 1)` bits, but the scalar CSR RVV input used `log2Ceil(rvvVlen)` bits. With `rvvVlen=128`, that truncated `VL=128` to zero when software read the `vl` CSR. The `vsetvl` instruction result still returned 128, so the existing test missed the bug because it read `vl_out1` twice.

This widens the CSR-side `vl` input and updates the cocotb test to check the separate `vl_out2` value read through `csrr vl`.

Tested:
- python3 -m py_compile tests/cocotb/rvv_assembly_cocotb_test.py
- bazel query --noshow_progress //tests/cocotb:rvv_assembly_cocotb_test_vsetvl_test
- bazel test //tests/cocotb:rvv_assembly_cocotb_test_vsetvl_test
