### PR TITLE
feat: add bf16 kernels for sigmoid and softmax

### DIFF
--- a/tests/cocotb/rvv/ml_ops/bf16_activations/BUILD
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/BUILD
@@ -1,0 +1,178 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//rules:coralnpu_v2.bzl", "coralnpu_v2_binary")
+load("//rules:coco_tb.bzl", "cocotb_test_suite")
+load(
+    "//tests/cocotb:build_defs.bzl",
+    "VCS_BUILD_ARGS",
+    "VCS_DEFINES",
+    "VCS_TEST_ARGS",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+# Enable native bf16<->fp32 conversion (Zvfbfmin: VFWCVTBF16 / VFNCVTBF16). The
+# RvvCoreMiniAxi core synthesizes these instructions (--enableVectorBf16=True),
+# but the toolchain's default -march (rv32imf_zve32f_zicsr_zifencei_zbb) omits
+# zvfbfmin, so the compiler will not emit them. These copts override -march for 
+# just these targets, which makes rvv_math.h take its native-conversion path (the
+# later -march on the command line wins). Drop this for fall back the the 
+# integer-only conversion path with no behavioral change.
+BF16_NATIVE_COPTS = ["-march=rv32imf_zve32f_zvfbfmin_zicsr_zifencei_zbb"]
+
+coralnpu_v2_binary(
+    name = "rvv_math_test",
+    srcs = ["rvv_math_runner.cc"],
+    hdrs = [
+        "rvv_math.h",
+        "//sw/utils:utils.h",
+    ],
+    copts = BF16_NATIVE_COPTS,
+    dtcm_size_kbytes = 512,
+    itcm_size_kbytes = 512,
+)
+
+coralnpu_v2_binary(
+    name = "sigmoid_bf16_test",
+    srcs = [
+        "sigmoid_bf16_kernel.cc",
+        "sigmoid_bf16_runner.cc",
+    ],
+    hdrs = [
+        "rvv_math.h",
+        "//sw/utils:utils.h",
+    ],
+    copts = BF16_NATIVE_COPTS,
+    dtcm_size_kbytes = 512,
+    itcm_size_kbytes = 512,
+)
+
+coralnpu_v2_binary(
+    name = "softmax_bf16_test",
+    srcs = [
+        "softmax_bf16_kernel.cc",
+        "softmax_bf16_runner.cc",
+    ],
+    hdrs = [
+        "rvv_math.h",
+        "//sw/utils:utils.h",
+    ],
+    copts = BF16_NATIVE_COPTS,
+    dtcm_size_kbytes = 512,
+    itcm_size_kbytes = 512,
+)
+
+RVV_MATH_TESTCASES = ["rvv_math_test"]
+cocotb_test_suite(
+    name = "rvv_math_cocotb_test",
+    simulators = [
+        "verilator",
+        "vcs",
+    ],
+    testcases = RVV_MATH_TESTCASES,
+    testcases_vname = "RVV_MATH_TESTCASES",
+    tests_kwargs = {
+        "hdl_toplevel": "RvvCoreMini_ITCM512KB_DTCM512KBAxi",
+        "waves": False,
+        "seed": "42",
+        "tags": ["manual"],
+        "test_module": ["rvv_math_cocotb_test.py"],
+        "deps": [
+            "//coralnpu_test_utils:sim_test_fixture",
+            "@bazel_tools//tools/python/runfiles",
+        ],
+        "data": [":rvv_math_test.elf"],
+        "size": "enormous",
+    },
+    vcs_build_args = VCS_BUILD_ARGS,
+    vcs_data = [
+        ":rvv_math_test.elf",
+        "//tests/cocotb:xprop.cfg",
+        "@coralnpu_hw//hdl/verilog:dpi_files",
+    ],
+    vcs_defines = VCS_DEFINES,
+    vcs_test_args = VCS_TEST_ARGS,
+    vcs_verilog_sources = ["//hdl/chisel/src/coralnpu:alu_cc_library_emit_verilog"],
+    verilator_model = "//tests/cocotb:rvv_core_mini_itcm512kb_dtcm512kb_axi_model",
+)
+
+SIGMOID_BF16_TESTCASES = ["sigmoid_bf16_test"]
+cocotb_test_suite(
+    name = "sigmoid_bf16_cocotb_test",
+    simulators = [
+        "verilator",
+        "vcs",
+    ],
+    testcases = SIGMOID_BF16_TESTCASES,
+    testcases_vname = "SIGMOID_BF16_TESTCASES",
+    tests_kwargs = {
+        "hdl_toplevel": "RvvCoreMini_ITCM512KB_DTCM512KBAxi",
+        "waves": False,
+        "seed": "42",
+        "tags": ["manual"],
+        "test_module": ["sigmoid_bf16_cocotb_test.py"],
+        "deps": [
+            "//coralnpu_test_utils:sim_test_fixture",
+            "@bazel_tools//tools/python/runfiles",
+        ],
+        "data": [":sigmoid_bf16_test.elf"],
+        "size": "enormous",
+    },
+    vcs_build_args = VCS_BUILD_ARGS,
+    vcs_data = [
+        ":sigmoid_bf16_test.elf",
+        "//tests/cocotb:xprop.cfg",
+        "@coralnpu_hw//hdl/verilog:dpi_files",
+    ],
+    vcs_defines = VCS_DEFINES,
+    vcs_test_args = VCS_TEST_ARGS,
+    vcs_verilog_sources = ["//hdl/chisel/src/coralnpu:alu_cc_library_emit_verilog"],
+    verilator_model = "//tests/cocotb:rvv_core_mini_itcm512kb_dtcm512kb_axi_model",
+)
+
+SOFTMAX_BF16_TESTCASES = ["softmax_bf16_test"]
+cocotb_test_suite(
+    name = "softmax_bf16_cocotb_test",
+    simulators = [
+        "verilator",
+        "vcs",
+    ],
+    testcases = SOFTMAX_BF16_TESTCASES,
+    testcases_vname = "SOFTMAX_BF16_TESTCASES",
+    tests_kwargs = {
+        "hdl_toplevel": "RvvCoreMini_ITCM512KB_DTCM512KBAxi",
+        "waves": False,
+        "seed": "42",
+        "tags": ["manual"],
+        "test_module": ["softmax_bf16_cocotb_test.py"],
+        "deps": [
+            "//coralnpu_test_utils:sim_test_fixture",
+            "@bazel_tools//tools/python/runfiles",
+        ],
+        "data": [":softmax_bf16_test.elf"],
+        "size": "enormous",
+    },
+    vcs_build_args = VCS_BUILD_ARGS,
+    vcs_data = [
+        ":softmax_bf16_test.elf",
+        "//tests/cocotb:xprop.cfg",
+        "@coralnpu_hw//hdl/verilog:dpi_files",
+    ],
+    vcs_defines = VCS_DEFINES,
+    vcs_test_args = VCS_TEST_ARGS,
+    vcs_verilog_sources = ["//hdl/chisel/src/coralnpu:alu_cc_library_emit_verilog"],
+    verilator_model = "//tests/cocotb:rvv_core_mini_itcm512kb_dtcm512kb_axi_model",
+)
+

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math.h
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math.h
@@ -1,0 +1,240 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TESTS_COCOTB_RVV_ML_OPS_BF16_ACTIVATIONS_RVV_MATH_H_
+#define TESTS_COCOTB_RVV_ML_OPS_BF16_ACTIVATIONS_RVV_MATH_H_
+
+#include <riscv_vector.h>
+
+#include <stddef.h>
+#include <stdint.h>
+// Shared RVV helpers for the bf16 activation kernels. Data is raw bf16
+// (uint16); math is fp32 vector at LMUL=8 and need a vector-FP core
+// (enableFloat=True / Zve32f)
+
+// bf16<->fp32 conversion has two compile=time paths, bti-identical on finite 
+// inputs (round-to-nearest-even)
+//  -   Native (Zvfbfmin): one VFWCVTBF16 / VFNCVTBF16 each. Requires `zvfbfmin`
+//      in -march; the RvvCoreMiniAxi core synthesizes there.
+//  -   Fallback (integer-only): used when Zvfbfmin is absent, so the kernels
+//      still build on a plain Zve32f core.
+#if defined (__riscv_zvfbfmin)
+// bf16 -> fp32: one widening covert (bf16 is the top 16 bits of fp32)
+inline vfloat32m8_t RvvLoadBf16AsF32m8(const uint16_t* src, size_t vl) {
+    vbfloat16m4_t b = __riscv_vreinterpret_v_u16m4_bf16m4(__riscv_vle16_v_u16m4(src, vl));
+    return __riscv_vfwcvtbf16_f_f_v_f32m8(b, vl);
+}
+// fp32 -> bf16: one narrowing convert (round-to-nearest-even)
+inline void RvvStoreF32AsBf16m8(uint16_t* dst, vfloat32m8_t x, size_t vl) {
+    vbfloat16m4_t b = __riscv_vfncvtbf16_f_f_w_bf16m4(x, vl);
+    __riscv_vse16_v_u16m4(dst, __riscv_vreinterpret_v_bf16m4_u16m4(b), vl);
+}
+
+#else
+// bf16 -> fp32: zero-extend the 16-bits pattern to 32 bits and shift left 16
+inline vfloat32m8_t RvvLoadBf16AsF32m8(const uint16_t* src, size_t vl) {
+    vuint16m4_t b = __riscv_vle16_v_u16m4(src, vl);
+    vuint32m8_t w = __riscv_vzext_vf2_u32m8(b, vl);
+    w = __riscv_vsll_vx_u32m8(w, 16, vl);
+    return __riscv_vreinterpret_v_u32m8_f32m8(w);
+}
+// fp32 -> bf 16 with round-to-nearest-even. 
+// Outputs of sigmoid/softmax are finite, so no NaN/Inf is needed.
+inline void RvvStoreF32AsBf16m8(uint16_t* dst, vfloat32m8_t x, size_t vl) {
+    vuint32m8_t bits = __riscv_vreinterpret_v_f32m8_u32m8(x);
+    vuint32m8_t upper_lsb = __riscv_vand_vx_u32m8(__riscv_vsrl_vx_u32m8(bits, 16, vl), 1, vl);
+    vuint32m8_t rounding_bias = __riscv_vadd_vx_u32m8(upper_lsb, 0x7fff, vl);
+    vuint32m8_t rounded = __riscv_vadd_vv_u32m8(bits, rounding_bias, vl);
+    vuint16m4_t bf16 = __riscv_vnsrl_wx_u16m4(rounded, 16, vl);
+    __riscv_vse16_v_u16m4(dst, bf16, vl);
+}
+#endif
+// exp(x) = 2^i * P(g), y = x*log2(e), i = rint(y), g = y - i, |g| <= 0.5
+// Base-2 reduction makes g exavt in fp32 (no Cody-Waite term). P is a degree-2
+// Remez minimax fit of 2^g on [-0.5, 0.5] (rel err 1.73e-3 < half a bf16 ULP),
+// so the bf16 result is within 1 ULP of correctly-rounded exp. Evaluated by
+// nested Hornor with scalar-operand ops (no vector constant splat).
+// Tail: the argument is clamped so 2^i stays finite; x below ~-87.68 gives
+// i <= -127, reconstructing 2^i as +0.0 (flush to zero, never subnormal)
+namespace rvv_math_internal {
+constexpr float kExp2D0 = 1.0004431f;   // 0x3f800e85
+constexpr float kExp2D1 = 0.703448f;    // 0x3f34152b
+constexpr float kExp2D2 = 0.23842894f;  // 0x3e7426b7
+constexpr float kLog2E = 1.4426950408889634f;
+// `log2e_signed` is +-log2e(e), constant-folded after inlining; x must be
+// pre-clamped so y = x*log2e_signed lands in [-126.96, + 126.96]
+inline vfloat32m8_t RvvExp2Core(vfloat32m8_t x, float log2e_signed, size_t vl) {
+    vfloat32m8_t y = __riscv_vfmul_vf_f32m8(x, log2e_signed, vl);
+    vint32m8_t i = __riscv_vfcvt_x_f_v_i32m8(y, vl);    // rint, frm=RNE
+    vfloat32m8_t g = __riscv_vfsub_vv_f32m8(y, __riscv_vfcvt_f_x_v_f32m8(i, vl), vl);
+    vfloat32m8_t t = __riscv_vfmul_vf_f32m8(g, kExp2D2, vl);    // p = (d2*g+d1)*g+d0
+    t = __riscv_vfadd_vf_f32m8(t, kExp2D1, vl);
+    vfloat32m8_t p = __riscv_vfmul_vv_f32m8(t, g, vl);
+    p = __riscv_vfadd_vf_f32m8(p, kExp2D0, vl);
+    vint32m8_t exp_bits = __riscv_vadd_vx_i32m8(i, 127, vl);
+    exp_bits = __riscv_vsll_vx_i32m8(exp_bits, 23, vl);
+    vfloat32m8_t scale = __riscv_vreinterpret_v_i32m8_f32m8(exp_bits);
+    return __riscv_vfmul_vv_f32m8(p, scale, vl);
+}
+}   // namespace rvv_math_internal
+// exp(x) for arbitrary finite x; clamps to [-88, 88]
+inline vfloat32m8_t RvvExpF32m8(vfloat32m8_t x, size_t vl) {
+    x = __riscv_vfmax_vf_f32m8(x, -88.0f, vl);
+    x = __riscv_vfmin_vf_f32m8(x, 88.0f, vl);
+    return rvv_math_internal::RvvExp2Core(x, rvv_math_internal::kLog2E, vl);
+}
+// exp(x) for x <= 0 only: skips the upper clamp (one instruction cheaper) 
+// PRECONDITION: every active element x <= 0; a positive x > 88 assembles and
+// exponent field >= 255 (Inf/NaN)
+inline vfloat32m8_t RvvExpNonPosF32m8(vfloat32m8_t x, size_t vl) {
+    x = __riscv_vfmax_vf_f32m8(x, -88.0f, vl);
+    return rvv_math_internal::RvvExp2Core(x, rvv_math_internal::kLog2E, vl);
+}
+// exp(-x) for arbitrary finite x: the negation is folded into the reduction 
+// (y = x * -log2(e)), saving the caller an explicit vfneg. Clamps x to [-88, 88]
+inline vfloat32m8_t RvvExpNegF32m8(vfloat32m8_t x, size_t vl) {
+    x = __riscv_vfmax_vf_f32m8(x, -88.0f, vl);
+    x = __riscv_vfmin_vf_f32m8(x, 88.0f, vl);
+    return rvv_math_internal::RvvExp2Core(x, -rvv_math_internal::kLog2E, vl);
+}
+inline vfloat32m8_t RvvExp2D0Splat(size_t vl) {
+    return __riscv_vfmv_v_f_f32m8(rvv_math_internal::kExp2D0, vl);
+}
+inline vfloat32m8_t RvvExp2CoreFMA(vfloat32m8_t x, float log2e_signed, vfloat32m8_t d0v, size_t vl) {
+    vfloat32m8_t y = __riscv_vfmul_vf_f32m8(x, log2e_signed, vl);
+    vint32m8_t i = __riscv_vfcvt_x_f_v_i32m8(y, vl);  // rint, frm=RNE
+    vfloat32m8_t g =
+        __riscv_vfsub_vv_f32m8(y, __riscv_vfcvt_f_x_v_f32m8(i, vl), vl);  // exact
+    vfloat32m8_t t = __riscv_vfmul_vf_f32m8(g, rvv_math_internal::kExp2D2, vl);
+    t = __riscv_vfadd_vf_f32m8(t, rvv_math_internal::kExp2D1, vl);
+    vfloat32m8_t p = __riscv_vfmadd_vv_f32m8(t, g, d0v, vl);  // p = t*g + d0 (fused)
+    vint32m8_t exp_bits = __riscv_vadd_vx_i32m8(i, 127, vl);
+    exp_bits = __riscv_vsll_vx_i32m8(exp_bits, 23, vl);
+    vfloat32m8_t scale = __riscv_vreinterpret_v_i32m8_f32m8(exp_bits);
+    return __riscv_vfmul_vv_f32m8(p, scale, vl);
+}
+// exp(-x) using the FMA core; `d0v` is the hoisted RvvExp2D0Splat(). Clamps
+// x to [-88, 88] (which clamps the exp argument -x to the same interval).
+inline vfloat32m8_t RvvExpNegFMA(vfloat32m8_t x, vfloat32m8_t d0v, size_t vl) {
+    x = __riscv_vfmax_vf_f32m8(x, -88.0f, vl);
+    x = __riscv_vfmin_vf_f32m8(x, 88.0f, vl);
+    return RvvExp2CoreFMA(x, -rvv_math_internal::kLog2E, d0v, vl);
+}
+
+// Scalar-FPU mirror of RvvExpNonPosF32m8, bit-for-bit identical (same reduction,
+// polynomial, flush-to-zero tail), for the online softmax's scalar rescale.
+// The RNE convert is emitted explicitly as fcvt.w.s to match the vector path
+// and avoid a libm lrintf call. PRECONDITION: x <= 0 (or -inf)
+inline float ScalarExpNonPosF32(float x) {
+    using rvv_math_internal::kExp2D0;
+    using rvv_math_internal::kExp2D1;
+    using rvv_math_internal::kExp2D2;
+    if (x < -88.0f) x = -88.0f;  // also catches -inf
+    const float y = x * rvv_math_internal::kLog2E;
+    int32_t i;
+    __asm__("fcvt.w.s %0, %1, rne" : "=r"(i) : "f"(y));  // rint, RNE
+    const float g = y - static_cast<float>(i);
+    const float p = (kExp2D2 * g + kExp2D1) * g + kExp2D0;  // same nesting as vector path
+    const int32_t exp_bits = (i + 127) << 23;
+    float scale;
+    __builtin_memcpy(&scale, &exp_bits, sizeof(scale));
+    return p * scale;
+}
+// Reciprocal via vfrec7 (~7-bit) + one Newton-Raphson step y1 = y0 * (2 - d*y0) ->
+// ~14-bit, ample for bf16. Cheaper than a full vfdiv, d must be positive-normal
+inline vfloat32m8_t RvvRecip7F32m8(vfloat32m8_t d, size_t vl) {
+    vfloat32m8_t y = __riscv_vfrec7_v_f32m8(d, vl);
+    vfloat32m8_t dy = __riscv_vfmul_vv_f32m8(d, y, vl);
+    vfloat32m8_t two_minus = __riscv_vfrsub_vf_f32m8(dy, 2.0f, vl);
+    return __riscv_vfmul_vv_f32m8(y, two_minus, vl);
+}
+// Raw vfrec7 estimate, no refinement (~7-bit, one op). The bf16 result can
+// reach ~3 ULP (vs ~1 with the Newton step); use only where that is acceptable.
+// d must be positive-normal
+inline vfloat32m8_t RvvRecip7RawF32m8(vfloat32m8_t d, size_t vl) {
+    return __riscv_vfrec7_v_f32m8(d, vl);
+}
+// Widen an already-loaded raw bf16 vector (u16 bit patterns) to f32 -- the
+// convert half of RvvLoadBf16AsF32m8, for callers that also need the raw
+// vector in the integer domain (e.g. sign-magnitude max keying below).
+#if defined(__riscv_zvfbfmin)
+inline vfloat32m8_t RvvWidenBf16ToF32m8(vuint16m4_t b, size_t vl) {
+    return __riscv_vfwcvtbf16_f_f_v_f32m8(__riscv_vreinterpret_v_u16m4_bf16m4(b), vl);
+}
+#else
+inline vfloat32m8_t RvvWidenBf16ToF32m8(vuint16m4_t b, size_t vl) {
+    vuint32m8_t w = __riscv_vzext_vf2_u32m8(b, vl);
+    w = __riscv_vsll_vx_u32m8(w, 16, vl);
+    return __riscv_vreinterpret_v_u32m8_f32m8(w);
+}
+#endif
+// Integer-domain bf16 max. Sign-magnitude keying makes unsigned integer order
+// match float order for every non-NaN bf16 (verified over all 65536 bit patterns;
+// +0 keys above -0, matching vfmax), so callers stay bit-identical to a 
+// vfredmax while skipping the fp32 FRDT reduction. NaN (outside contract)
+// would key above +inf. key = x ^ ((x >> arith 15) | 0x8000)
+inline vuint16m4_t RvvBf16MaxKeyM4(vuint16m4_t x, size_t vl) {
+    vint16m4_t m = __riscv_vsra_vx_i16m4(__riscv_vreinterpret_v_u16m4_i16m4(x), 15, vl);
+    vuint16m4_t mask = __riscv_vor_vx_u16m4(__riscv_vreinterpret_v_i16m4_u16m4(m), 0x8000, vl);
+    return __riscv_vxor_vv_u16m4(x, mask, vl);
+}
+// Reduce keys to the single max key. key(-inf) = 0x007F, so a zero seed is
+// below every finite key.
+inline uint16_t RvvBf16MaxKeyReduceM4(vuint16m4_t keys, size_t vl) {
+    vuint16m1_t r = __riscv_vredmaxu_vs_u16m4_u16m1(keys, __riscv_vmv_v_x_u16m1(0, 1), vl);
+    return __riscv_vmv_x_s_u16m1_u16(r);
+}
+// Same reduce, but seeded with a caller-supplied `seed` (a running max key)
+// instead of the constant 0. Returns max(seed, keys). Folding the running-max
+// comparison into the reduction seed keeps the seed LOOP-VARIANT, so it is NOT
+// hoisted out of the loop and spilled: under register pressure (the online
+// softmax's dv accumulator + exp working set fill all four m8 groups) a
+// constant seed gets LICM-hoisted then evicted to the stack and reloaded every
+// strip; a loop-variant seed is instead rematerialized in-loop as one vmv.s.x.
+// For seed = 0 this is identical to RvvBf16MaxKeyReduceM4.
+inline uint16_t RvvBf16MaxKeyReduceSeededM4(vuint16m4_t keys, uint16_t seed, size_t vl) {
+    vuint16m1_t r = __riscv_vredmaxu_vs_u16m4_u16m1(
+        keys, __riscv_vmv_s_x_u16m1(seed, 1), vl);
+    return __riscv_vmv_x_s_u16m1_u16(r);
+}
+inline uint16_t RvvBf16UnKey(uint16_t k) {
+    return (k & 0x8000) ? (uint16_t)(k ^ 0x8000) : (uint16_t)(~k);
+}
+inline float Bf16BitsToF32(uint16_t b) {
+    const uint32_t u = (uint32_t)b << 16;
+    float f;
+    __builtin_memcpy(&f, &u, sizeof(f));
+    return f;
+}
+// Tree-fold sum of a FULL-WIDTH f32 accumulator (all VLMAX lanes valid; zero
+// are fine), then a short reduction over 4 lanes. Cheaper than a flat
+// vfredusum over VLMAX. NOTE: this changes summation ORDER, so kernels that
+// must stay bit-identical to EACH OTHER must all use this same fold
+inline float RvvTreeSumF32m8(vfloat32m8_t acc) {
+    vfloat32m4_t s4 = __riscv_vfadd_vv_f32m4(
+        __riscv_vget_v_f32m8_f32m4(acc, 0), __riscv_vget_v_f32m8_f32m4(acc, 1),
+        __riscv_vsetvlmax_e32m4());
+    vfloat32m2_t s2 = __riscv_vfadd_vv_f32m2(
+        __riscv_vget_v_f32m4_f32m2(s4, 0), __riscv_vget_v_f32m4_f32m2(s4, 1),
+        __riscv_vsetvlmax_e32m2());
+    const size_t vl4 = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t s1 = __riscv_vfadd_vv_f32m1(
+        __riscv_vget_v_f32m2_f32m1(s2, 0), __riscv_vget_v_f32m2_f32m1(s2, 1),
+        vl4);
+    vfloat32m1_t r = __riscv_vfredusum_vs_f32m1_f32m1(
+        s1, __riscv_vfmv_v_f_f32m1(0.0f, 1), vl4);
+    return __riscv_vfmv_f_s_f32m1_f32(r);
+}
+
+#endif // TESTS_COCOTB_RVV_ML_OPS_BF16_ACTIVATIONS_RVV_MATH_H_

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math_cocotb_test.py
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math_cocotb_test.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import cocotb
+import numpy as np
+from bazel_tools.tools.python.runfiles import runfiles
+
+from coralnpu_test_utils.sim_test_fixture import Fixture
+
+CSR_BASE = 0x200000
+ELF = "coralnpu_hw/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math_test.elf"
+HALF_ULP = 2.0**-8  # bf16 half-ULP relative spacing (ship line)
+
+# bf16 patterns for the widen check: signed zeros, +-1, +-2, +-inf, q/sNaN, and
+# the smallest/largest sub/normal magnitudes.
+BF16_SPECIALS = np.array(
+    [
+        0x0000,
+        0x8000,
+        0x3F80,
+        0xBF80,
+        0x4000,
+        0x7F80,
+        0xFF80,
+        0x7FC0,
+        0xFFC0,
+        0x7F81,
+        0x0001,
+        0x8001,
+        0x007F,
+        0x0080,
+        0x7F7F,
+        0xFF7F,
+    ],
+    dtype=np.uint16,
+)
+
+
+def f32_to_bf16(x):
+    u = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    return ((u + np.uint32(0x7FFF) + lsb) >> np.uint32(16)).astype(np.uint16)
+
+
+def bf16_to_fp32(b):
+    return (b.astype(np.uint32) << np.uint32(16)).view(np.float32)
+
+
+# bf16 patterns for the integer-key max: signed zeros, +-inf, +-2, +-1. NaN is
+# excluded by contract (it keys above +inf, which the kernels never see).
+MAXKEY_SPECIALS = np.array(
+    [0x0000, 0x8000, 0x7F80, 0xFF80, 0x4000, 0xC000, 0x3F80, 0xBF80], dtype=np.uint16
+)
+
+
+def make_narrow_inputs(rng, n):
+    # Random fp32 plus exact half-way ties (low 16 bits = 0x8000, keep-bit varying)
+    # so round-to-nearest-even must break both ways. Magnitudes stay moderate so
+    # `bits + 0x7fff` never overflows uint32 in device or reference.
+    x = rng.uniform(-1000.0, 1000.0, n).astype(np.float32)
+    u = x.view(np.uint32).copy()
+    k = max(1, n // 3)
+    u[:k] = (u[:k] & np.uint32(0xFFFF0000)) | np.uint32(0x8000)  # tie, keep-bit varies
+    u[k : 2 * k] = (u[k : 2 * k] & np.uint32(0xFFFE0000)) | np.uint32(
+        0x8000
+    )  # tie, keep-bit even
+    return u.view(np.float32)
+
+
+@cocotb.test()
+async def rvv_math_test(dut):
+    log = dut._log
+    r = runfiles.Create()
+    fixture = await Fixture.Create(dut, csr_base_addr=CSR_BASE)
+    elf = r.Rlocation(ELF)
+    if not elf or not os.path.exists(elf):
+        raise FileNotFoundError(f"ELF not found at {elf}")
+    await fixture.load_elf_and_lookup_symbols(
+        elf,
+        [
+            "cvt_in",
+            "cvt_out",
+            "narrow_in",
+            "narrow_out",
+            "exp_in",
+            "exp_out",
+            "exp_neg_out",
+            "expnp_in",
+            "expnp_out",
+            "scalar_exp_out",
+            "recip_in",
+            "recip_out",
+            "recip_raw_out",
+            "widen_in",
+            "widen_out",
+            "exp_neg_fma_out",
+            "maxkey_in",
+            "maxkey_out",
+            "treesum_in",
+            "treesum_out",
+            "active_n",
+            "cycle_count",
+        ],
+    )
+    await fixture.core_mini_axi.reset()
+    rng = np.random.default_rng(42)
+
+    for n in [1, 31, 33, 256, 643, 4096]:  # includes non-multiples of the 32-lane group
+        cvt = f32_to_bf16(rng.uniform(-10.0, 10.0, n).astype(np.float32))
+        narrow_in = make_narrow_inputs(rng, n)
+        exp_in = rng.uniform(-80.0, 80.0, n).astype(np.float32)
+        exp_in[: min(7, n)] = np.array(
+            [-100, -88, -87.9, 0, 87.9, 88, 100], np.float32
+        )[: min(7, n)]
+        expnp_in = -np.abs(exp_in).astype(np.float32)  # nonpos form needs x <= 0
+        expnp_in[: min(4, n)] = np.array([0, -0.0, -88, -100], np.float32)[: min(4, n)]
+        recip_in = np.exp(rng.uniform(np.log(1e-3), np.log(1e3), n)).astype(np.float32)
+        recip_in[: min(8, n)] = np.array(
+            [1.0, 1.0000061, 2.0, 0.5, 1e-3, 1e3, 1e-6, 1e6], np.float32
+        )[: min(8, n)]
+        widen_in = rng.integers(0, 1 << 16, n, dtype=np.uint16)
+        widen_in[: min(BF16_SPECIALS.size, n)] = BF16_SPECIALS[
+            : min(BF16_SPECIALS.size, n)
+        ]
+        # integer-key max: finite bf16 (from fp32, never NaN) plus signed-zero /
+        # +-inf specials so the key ordering and +0 > -0 tie-break are exercised.
+        maxkey_in = f32_to_bf16(rng.uniform(-100.0, 100.0, n).astype(np.float32))
+        maxkey_in[: min(MAXKEY_SPECIALS.size, n)] = MAXKEY_SPECIALS[
+            : min(MAXKEY_SPECIALS.size, n)
+        ]
+        # tree-fold sum: positive, moderate range (mirrors summing exp outputs).
+        treesum_in = rng.uniform(1e-3, 2.0, n).astype(np.float32)
+
+        await fixture.write("active_n", np.array([n], np.uint32))
+        for name, val in [
+            ("cvt_in", cvt),
+            ("narrow_in", narrow_in),
+            ("exp_in", exp_in),
+            ("expnp_in", expnp_in),
+            ("recip_in", recip_in),
+            ("widen_in", widen_in),
+            ("maxkey_in", maxkey_in),
+            ("treesum_in", treesum_in),
+        ]:
+            await fixture.write(name, val)
+        for name, dt in [
+            ("cvt_out", np.uint16),
+            ("narrow_out", np.uint16),
+            ("exp_out", np.float32),
+            ("exp_neg_out", np.float32),
+            ("expnp_out", np.float32),
+            ("scalar_exp_out", np.float32),
+            ("recip_out", np.float32),
+            ("recip_raw_out", np.float32),
+            ("widen_out", np.float32),
+            ("exp_neg_fma_out", np.float32),
+            ("maxkey_out", np.float32),
+            ("treesum_out", np.float32),
+        ]:
+            await fixture.write(name, np.zeros(n, dt))
+        await fixture.run_to_halt(timeout_cycles=10_000_000)
+
+        # (1) round-trip is the identity for bf16 values; (2) RNE narrow is bit-exact.
+        np.testing.assert_array_equal(
+            (await fixture.read("cvt_out", n * 2)).view(np.uint16), cvt
+        )
+        np.testing.assert_array_equal(
+            (await fixture.read("narrow_out", n * 2)).view(np.uint16),
+            f32_to_bf16(narrow_in),
+        )
+
+        # (3) exp: all three vector entries + scalar mirror vs clamped exact exp.
+        # The kernel clamps to [-88, 88]; the atol floor lets the flushed tail
+        # (golden ~1e-39 -> 0 on device) compare equal so rtol applies where the
+        # result is non-negligible.
+        gp = np.exp(np.clip(exp_in, -88, 88).astype(np.float64))
+        gn = np.exp(-np.clip(exp_in, -88, 88).astype(np.float64))
+        gnp = np.exp(np.clip(expnp_in, -88, 88).astype(np.float64))
+        eo = (await fixture.read("exp_out", n * 4)).view(np.float32)
+        en = (await fixture.read("exp_neg_out", n * 4)).view(np.float32)
+        enp = (await fixture.read("expnp_out", n * 4)).view(np.float32)
+        es = (await fixture.read("scalar_exp_out", n * 4)).view(np.float32)
+        np.testing.assert_allclose(eo, gp, rtol=3.5e-3, atol=1e-30)
+        np.testing.assert_allclose(en, gn, rtol=3.5e-3, atol=1e-30)
+        np.testing.assert_allclose(enp, gnp, rtol=3.5e-3, atol=1e-30)
+        np.testing.assert_allclose(es, gnp, rtol=3.5e-3, atol=1e-30)  # scalar vs exact
+        np.testing.assert_allclose(
+            es, enp, rtol=1e-3, atol=1e-30
+        )  # scalar tracks vector
+        # FMA-core exp(-x): meets the same ship criterion AND is BIT-IDENTICAL to
+        # the split-Horner exp_neg at bf16 output (the property the sigmoid kernels
+        # rely on -- the fused single-rounding differs only below bf16 resolution).
+        efma = (await fixture.read("exp_neg_fma_out", n * 4)).view(np.float32)
+        np.testing.assert_allclose(efma, gn, rtol=3.5e-3, atol=1e-30)
+        np.testing.assert_array_equal(f32_to_bf16(efma), f32_to_bf16(en))
+        # Ship criterion on the dense large-n rows: rel err < bf16 half-ULP.
+        if n >= 256:
+
+            def rel(o, g):
+                m = g > 1e-30
+                return float(np.max(np.abs(o[m] - g[m]) / g[m]))
+
+            rw = max(rel(eo, gp), rel(en, gn), rel(enp, gnp))
+            assert (
+                rw < HALF_ULP
+            ), f"exp rel {rw:.2e} >= {HALF_ULP:.1e}"
+            log.info(
+                f"exp rel err (n={n}): {rw:.2e} < {2.0 ** -9:.1e} "
+                f"(bar: {HALF_ULP:.1e})"
+            )
+
+        # (4) reciprocal: refined (vfrec7 + 1 Newton ~2^-14; rtol 2e-4 fails loudly
+        # if the Newton step is dropped) and raw (vfrec7 alone, bounded at 2^-7 by
+        # the RVV spec; rtol 1.2e-2 gives ~50% margin over that bound). The raw path
+        # is what sigmoid kernel_id 2 uses.
+        recip_g = 1.0 / recip_in.astype(np.float64)
+        ro = (await fixture.read("recip_out", n * 4)).view(np.float32)
+        rr = (await fixture.read("recip_raw_out", n * 4)).view(np.float32)
+        np.testing.assert_allclose(ro, recip_g, rtol=2e-4, atol=1e-30)
+        np.testing.assert_allclose(rr, recip_g, rtol=1.2e-2, atol=1e-30)
+
+        # (4b) integer sign-magnitude-key max == exact bf16 max of the array. The
+        # key reorders bits so unsigned-int order matches float order (verified
+        # exhaustively in the header note); compare values so +0 == -0 is fine.
+        mk = float((await fixture.read("maxkey_out", 4)).view(np.float32)[0])
+        assert mk == float(
+            bf16_to_fp32(maxkey_in).max()
+        ), f"key-max {mk} != exact bf16 max at n={n}"
+
+        # (4c) tree-fold sum vs exact (fp64) sum. The fold changes summation order
+        # so compare with a tolerance covering fp32 accumulation over up to 4096
+        # well-conditioned positive terms.
+        ts = float((await fixture.read("treesum_out", 4)).view(np.float32)[0])
+        np.testing.assert_allclose(ts, treesum_in.astype(np.float64).sum(), rtol=5e-5)
+
+        # (5) widen bf16 -> fp32: bit-exact for every non-NaN class (compare raw u32
+        # so signed zeros / subnormals count). NaN bits are not portable across the
+        # native vs integer widen paths, so a NaN input need only stay some NaN.
+        wb = (await fixture.read("widen_out", n * 4)).view(np.uint32)
+        wg = widen_in.astype(np.uint32) << np.uint32(16)
+        is_nan = ((widen_in & 0x7F80) == 0x7F80) & ((widen_in & 0x007F) != 0)
+        np.testing.assert_array_equal(wb[~is_nan], wg[~is_nan])
+        no = wb[is_nan]
+        assert np.all(
+            (((no >> np.uint32(23)) & np.uint32(0xFF)) == 0xFF)
+            & ((no & np.uint32(0x7FFFFF)) != 0)
+        ), "widened NaN did not stay NaN"

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math_runner.cc
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math_runner.cc
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <riscv_vector.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math.h"
+
+#define MAX_N 4096
+#define EXTMEM __attribute__((section(".extmem"))) __attribute__((aligned(16)))
+
+extern "C" {
+uint16_t cvt_in[MAX_N] EXTMEM;      // round-trip: bf16 -> widen -> narrow -> bf16
+uint16_t cvt_out[MAX_N] EXTMEM;
+float narrow_in[MAX_N] EXTMEM;      // RNE narrow: arbitrary fp32 -> bf16
+uint16_t narrow_out[MAX_N] EXTMEM;
+float exp_in[MAX_N] EXTMEM;         // exp(x) general + folded exp(-x) on the same input
+float exp_out[MAX_N] EXTMEM;
+float exp_neg_out[MAX_N] EXTMEM;
+float expnp_in[MAX_N] EXTMEM;       // x <= 0: nonpos vector exp + scalar mirror
+float expnp_out[MAX_N] EXTMEM;
+float scalar_exp_out[MAX_N] EXTMEM;
+float recip_in[MAX_N] EXTMEM;       // positive-normal reciprocal
+float recip_out[MAX_N] EXTMEM;      // vfrec7 + Newton (~14-bit)
+float recip_raw_out[MAX_N] EXTMEM;  // vfrec7 raw, no refinement (~7-bit)
+uint16_t widen_in[MAX_N] EXTMEM;    // bf16 -> fp32, bit-exact (pattern << 16)
+float widen_out[MAX_N] EXTMEM;
+float exp_neg_fma_out[MAX_N] EXTMEM;  // FMA-core exp(-x): must match exp_neg_out at bf16
+uint16_t maxkey_in[MAX_N] EXTMEM;     // integer sign-magnitude-key max over the array
+float maxkey_out[MAX_N] EXTMEM;       // [0] = max value (helpers used by small-row/online)
+float treesum_in[MAX_N] EXTMEM;       // tree-fold sum over the array (positive-conditioned)
+float treesum_out[MAX_N] EXTMEM;      // [0] = sum
+uint32_t active_n EXTMEM = 256;
+uint32_t cycle_count EXTMEM = 0;
+}
+
+int main() {
+    if (active_n > MAX_N) return -1;
+    const int n = static_cast<int>(active_n);
+    uint32_t start;
+    asm volatile("csrr %0, mcycle" : "=r"(start) : : "memory");
+
+    for (int i = 0; i < n;) {  // round-trip + narrow (both strip-mined the same way)
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        RvvStoreF32AsBf16m8(cvt_out + i, RvvLoadBf16AsF32m8(cvt_in + i, vl), vl);
+        RvvStoreF32AsBf16m8(narrow_out + i, __riscv_vle32_v_f32m8(narrow_in + i, vl), vl);
+        i += vl;
+    }
+    for (int i = 0; i < n;) {  // exp: general + folded exp(-x)
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t x = __riscv_vle32_v_f32m8(exp_in + i, vl);
+        __riscv_vse32_v_f32m8(exp_out + i, RvvExpF32m8(x, vl), vl);
+        __riscv_vse32_v_f32m8(exp_neg_out + i, RvvExpNegF32m8(x, vl), vl);
+        i += vl;
+    }
+    for (int i = 0; i < n;) {  // nonpos exp (vector), plus scalar mirror per element
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t x = __riscv_vle32_v_f32m8(expnp_in + i, vl);
+        __riscv_vse32_v_f32m8(expnp_out + i, RvvExpNonPosF32m8(x, vl), vl);
+        i += vl;
+    }
+    for (int i = 0; i < n; ++i)  // scalar nonpos exp mirrors the online-softmax rescale
+        scalar_exp_out[i] = ScalarExpNonPosF32(expnp_in[i]);
+    for (int i = 0; i < n;) {  // reciprocal: refined (Newton) and raw (estimate only)
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t d = __riscv_vle32_v_f32m8(recip_in + i, vl);
+        __riscv_vse32_v_f32m8(recip_out + i, RvvRecip7F32m8(d, vl), vl);
+        __riscv_vse32_v_f32m8(recip_raw_out + i, RvvRecip7RawF32m8(d, vl), vl);
+        i += vl;
+    }
+    for (int i = 0; i < n;) {  // widen bf16 -> fp32
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        __riscv_vse32_v_f32m8(widen_out + i, RvvLoadBf16AsF32m8(widen_in + i, vl), vl);
+        i += vl;
+    }
+    {   // FMA-core exp(-x): hoist d0v once (mirrors the sigmoid kernels' path)
+        const size_t vlmax = __riscv_vsetvlmax_e32m8();
+        vfloat32m8_t d0v = RvvExp2D0Splat(vlmax);
+        for (int i = 0; i < n;) {
+            size_t vl = __riscv_vsetvl_e32m8(n - i);
+            vfloat32m8_t x = __riscv_vle32_v_f32m8(exp_in + i, vl);
+            __riscv_vse32_v_f32m8(exp_neg_fma_out + i, RvvExpNegFMA(x, d0v, vl), vl);
+            i += vl;
+        }
+    }
+    {   // integer sign-magnitude-key max over the whole array
+        uint16_t kmax = 0;  // key(-inf) = 0x007F, so 0 sits below every finite key
+        for (int i = 0; i < n;) {
+            size_t vl = __riscv_vsetvl_e16m4(n - i);
+            vuint16m4_t raw = __riscv_vle16_v_u16m4(maxkey_in + i, vl);
+            uint16_t kc = RvvBf16MaxKeyReduceM4(RvvBf16MaxKeyM4(raw, vl), vl);
+            if (kc > kmax) kmax = kc;
+            i += vl;
+        }
+        maxkey_out[0] = Bf16BitsToF32(RvvBf16UnKey(kmax));
+    }
+    {   // tree-fold sum: strided accumulate into a full-width m8, fold once
+        const size_t vlmax = __riscv_vsetvlmax_e32m8();
+        vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+        for (int i = 0; i < n;) {
+            size_t vl = __riscv_vsetvl_e32m8(n - i);
+            vfloat32m8_t v = __riscv_vle32_v_f32m8(treesum_in + i, vl);
+            acc = __riscv_vfadd_vv_f32m8_tu(acc, acc, v, vl);
+            i += vl;
+        }
+        treesum_out[0] = RvvTreeSumF32m8(acc);
+    }
+
+    uint32_t end;
+    asm volatile("csrr %0, mcycle" : "=r"(end) : : "memory");
+    cycle_count = end - start;
+    return 0;
+}

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_cocotb_test.py
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_cocotb_test.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import cocotb
+import numpy as np
+from bazel_tools.tools.python.runfiles import runfiles
+
+from coralnpu_test_utils.sim_test_fixture import Fixture
+
+# 512KB memory map shifts CSRs to 0x200000
+CSR_BASE = 0x200000
+ELF = "coralnpu_hw/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_test.elf"
+CANARY = np.uint16(0xBEEF)
+MAX_ULPS = 3
+VARIANTS = [(0, "vfrdiv"), (1, "vfrec7 NR"), (2, "vfrec7 raw")]
+
+
+def f32_to_bf16(x):
+    """float32 array -> raw bf16 bit patterns (uint16), round-to-nearest-even"""
+    u = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    return ((u + np.uint32(0x7FFF) + lsb) >> np.uint32(16)).astype(np.uint16)
+
+
+def bf16_to_fp32(b):
+    return (b.astype(np.uint32) << np.uint32(16)).view(np.float32)
+
+
+def check(dev, golden, label, max_ulps=MAX_ULPS, atol=1e-37):
+    golden = np.asarray(golden, dtype=np.float64)
+    ulp = np.abs(
+        dev.astype(np.int32) - f32_to_bf16(golden.astype(np.float32)).astype(np.int32)
+    )
+    abs_err = np.abs(bf16_to_fp32(dev).astype(np.float64) - golden)
+    over = (ulp > max_ulps) & (abs_err > atol)
+    if over.any():
+        w = int(np.argmax(np.where(over, ulp, -1)))
+        raise AssertionError(
+            f"{label}: {int(ulp[over].max())} ULP > {max_ulps} "
+            f"(dev={float(bf16_to_fp32(dev)[w]):.3e} golden={float(golden[w]):.3e})"
+        )
+    keep = ~((ulp > max_ulps) & (abs_err <= atol))
+    return int(ulp[keep].max()) if keep.any() else 0
+
+
+async def run(fixture, x, kernel_id=0, alias=0, repeat=1):
+    n = x.shape[0]
+    pad = 8
+    await fixture.write("active_n", np.array([n], dtype=np.uint32))
+    await fixture.write("kernel_id", np.array([kernel_id], dtype=np.uint32))
+    await fixture.write("alias", np.array([alias], dtype=np.uint32))
+    await fixture.write("repeat", np.array([repeat], dtype=np.uint32))
+    await fixture.write("sigmoid_in", f32_to_bf16(x))
+    await fixture.write("sigmoid_out", np.full(n + pad, CANARY, dtype=np.uint16))
+
+    sim_cycles = await fixture.run_to_halt(timeout_cycles=10_000_000)
+    out = (await fixture.read("sigmoid_out", (n + pad) * 2)).view(np.uint16)
+    if repeat >= 1:
+        np.testing.assert_array_equal(out[n:], np.full(pad, CANARY, np.uint16))
+    # cyc = int((await fixture.read("cycle_count", 4)).view(np.float32)[0])
+    xq = bf16_to_fp32(f32_to_bf16(x)).astype(np.float64)
+    golden = 1.0 / (1.0 + np.exp(-xq))
+    # golden = 1.0 / (1.0 + np.exp(-x.astype(np.float64)))
+    return out[:n], golden, sim_cycles
+
+
+async def _setup(dut):
+    r = runfiles.Create()
+    fixture = await Fixture.Create(dut, csr_base_addr=CSR_BASE)
+    elf_path = r.Rlocation(ELF)
+    if not elf_path or not os.path.exists(elf_path):
+        raise FileNotFoundError(f"Cound not find ELF at {elf_path}")
+    await fixture.load_elf_and_lookup_symbols(
+        elf_path,
+        [
+            "sigmoid_in",
+            "sigmoid_out",
+            "active_n",
+            "kernel_id",
+            "alias",
+            "repeat",
+            "cycle_count",
+        ],
+    )
+    await fixture.core_mini_axi.reset()
+    return fixture
+
+
+@cocotb.test()
+async def sigmoid_bf16_corr_test(dut):
+    fixture = await _setup(dut)
+    rng = np.random.default_rng(seed=7)
+    log = dut._log
+
+    outs = {}
+    for kid, name in VARIANTS:
+        worst = 0
+        x = np.linspace(-15.0, 15.0, 512).astype(np.float32)
+        x[:8] = [88.0, -88.0, 90.0, -90.0, 40.0, -40.0, 0.0, -0.0]
+        out, golden, _ = await run(fixture, x, kid)
+        outs[kid] = out
+        worst = max(worst, check(out, golden, "sweep"))
+        for n in [1, 31, 33, 640, 643]:
+            out, golden, _ = await run(
+                fixture, rng.uniform(-10.0, 10.0, n).astype(np.float32), kid
+            )
+            worst = max(worst, check(out, golden, "sweep"))
+        out, golden, _ = await run(
+            fixture, rng.uniform(-10.0, 10.0, n).astype(np.float32), kid, alias=1
+        )
+        worst = max(worst, check(out, golden, "in-place"))
+        log.info(f"sigmoid [{name}]: worst {worst} ULP (limit {MAX_ULPS})")
+
+    for kid in (1, 2):
+        diff = np.abs(outs[0].astype(np.int32) - outs[kid].astype(np.int32))
+        name = dict(VARIANTS)[kid]
+        log.info(
+            f"  vfrdiv vs {name}: {(diff == 0).mean() * 100:.1f}% bit-identical, "
+            f"max {int(diff.max())} ULP apart"
+        )
+
+
+@cocotb.test()
+async def sigmoid_bf16_perf_test(dut):
+    fixture = await _setup(dut)
+    rng = np.random.default_rng(seed=7)
+    log = dut._log
+
+    nbig = 4096
+    xb = rng.uniform(-12.0, 12.0, nbig).astype(np.float32)
+    _, _, startup = await run(fixture, xb, 0, repeat=0)
+    log.info(f"fixed startup (repeat=0): {startup} cyc")
+    base = None
+    for kid, name in VARIANTS:
+        out, golden, cyc = await run(fixture, xb, kid)
+        w = check(out, golden, name)
+        pc = cyc - startup
+        base = base or pc
+        log.info(
+            f"  {name:11s}: raw {cyc} cyc | per-call {pc} cyc "
+            f"({pc / nbig:.2f} cyc/elem, {base / pc:.3f}x, worst {w} ULP"
+        )

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_kernel.cc
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_kernel.cc
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bf16 logistic sigmoid, sigmoid(x) = 1 / (1 + exp(-x)), computed in fp32
+//
+// Three variants share the identical exp path (RvvExpNegF32m8, which folds the 
+// -x negation into the range reduction) and differ ONLU in the final divide:
+//  - SigmoidBf16               1/(1+e) via vfrdiv (correctlu rounded)
+//  - SigmoidBf16_Vfrec7        1/(1+e) via vfrec7 + one Newton step
+//  - SigmoidBf16_Vfrec7Raw     1/(1+e) via vfrec7, NO Newton step
+// vfrdiv uses the blocking FDIV unit; vfrec7* use the pipelined vfrec7;
+// vfrdiv/vfrec7_NR are <= 1 ULP; vfrec7_raw drops the Newton step for speed and can
+// reach ~3 ULP
+//
+// Data is raw bf16 (uint16). In-place (out == in) is safe: each VLMAX strip is 
+// loaded before its store and elements never cross strips
+#include <riscv_vector.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math.h"
+
+namespace {
+// e = exp(-x); denom = 1 + e; the caller supplies 1/denom
+inline vfloat32m8_t SigmoidDenom(const uint16_t* in, size_t i, vfloat32m8_t d0v, size_t vl) {
+    vfloat32m8_t x = RvvLoadBf16AsF32m8(in + i, vl);
+    vfloat32m8_t e = RvvExpNegFMA(x, d0v, vl);
+    return __riscv_vfadd_vf_f32m8(e, 1.0f, vl);
+}
+}  // namespace
+
+extern "C" {
+// baseline: 1/(1+exp(-x)) with a fp32 reciprocal (vfrdiv)
+bool SigmoidBf16(const uint16_t* in, uint16_t* out, size_t n) {
+    const vfloat32m8_t d0v = RvvExp2D0Splat(__riscv_vsetvlmax_e32m8());
+    for (size_t i = 0; i < n;) {
+        const size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t denom = SigmoidDenom(in, i, d0v,vl);
+        vfloat32m8_t y = __riscv_vfrdiv_vf_f32m8(denom, 1.0f, vl);
+        RvvStoreF32AsBf16m8(out + i, y, vl);
+        i += vl;
+    }
+    return true;
+}
+
+// reciprocal via vfrev7 + one Newton-Raphson step. denom = 1 + exp(-x)
+// is always >= 1 (positive-normal), so vfrec7 is well defined
+bool SigmoidBf16_Vfrec7(const uint16_t* in, uint16_t* out, size_t n) {
+    const vfloat32m8_t d0v = RvvExp2D0Splat(__riscv_vsetvlmax_e32m8());
+    for (size_t i = 0; i < n;) {
+        const size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t denom = SigmoidDenom(in, i, d0v, vl);
+        vfloat32m8_t y = RvvRecip7F32m8(denom, vl);
+        RvvStoreF32AsBf16m8(out + i, y, vl);
+        i += vl;
+    }
+    return true;
+}
+
+// reciprocal via vfrev7 with no Newton refinement. Same positive-narmal precondition.
+bool SigmoidBf16_Vfrec7Raw(const uint16_t* in, uint16_t* out, size_t n) {
+    const vfloat32m8_t d0v = RvvExp2D0Splat(__riscv_vsetvlmax_e32m8());
+    for (size_t i = 0; i < n;) {
+        const size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t denom = SigmoidDenom(in, i, d0v, vl);
+        vfloat32m8_t y = RvvRecip7RawF32m8(denom, vl);
+        RvvStoreF32AsBf16m8(out + i, y, vl);
+        i += vl;
+    }
+    return true;
+}
+}

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_runner.cc
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/sigmoid_bf16_runner.cc
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" void SigmoidBf16(const uint16_t *in, uint16_t *out, size_t n);
+extern "C" void SigmoidBf16_Vfrec7(const uint16_t *in, uint16_t *out, size_t n);
+extern "C" void SigmoidBf16_Vfrec7Raw(const uint16_t *in, uint16_t *out, size_t n);
+
+#define MAX_N 8192
+#define EXTMEM __attribute__((section(".extmem"))) __attribute__((aligned(16)))
+
+extern "C" {
+uint16_t sigmoid_in[MAX_N] EXTMEM;
+uint16_t sigmoid_out[MAX_N] EXTMEM;
+uint32_t active_n EXTMEM = 256;
+uint32_t kernel_id  EXTMEM = 0;
+uint32_t alias  EXTMEM = 0;
+uint32_t repeat EXTMEM = 0;
+uint32_t cycle_count EXTMEM = 0;
+}
+
+int main() {
+    if (active_n > MAX_N) return -1;
+    const int n = static_cast<int>(active_n);
+
+    const uint16_t* in_ptr = sigmoid_in;
+    if (alias != 0) {
+        for (int i = 0; i < n; ++i) sigmoid_out[i] = sigmoid_in[i];
+        in_ptr = sigmoid_out;
+    }
+
+    uint32_t start;
+    asm volatile("csrr %0, mcycle" : "=r"(start) : : "memory");
+
+    for (uint32_t r = 0; r < repeat; ++r) {
+        switch (kernel_id) {
+            case 1:     SigmoidBf16_Vfrec7(in_ptr, sigmoid_out, n);     break;
+            case 2:     SigmoidBf16_Vfrec7Raw(in_ptr, sigmoid_out, n);  break;
+            default:    SigmoidBf16(in_ptr, sigmoid_out, n);            break;
+        }
+    }
+    
+    uint32_t end;
+    asm volatile("csrr %0, mcycle" : "=r"(end) : : "memory");
+    cycle_count = end - start;
+    return 0;
+}

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_cocotb_test.py
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_cocotb_test.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import cocotb
+import numpy as np
+from bazel_tools.tools.python.runfiles import runfiles
+
+from coralnpu_test_utils.sim_test_fixture import Fixture
+
+# 512KB memory map shifts CSRs to 0x200000
+CSR_BASE = 0x200000
+ELF = "coralnpu_hw/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_test.elf"
+CANARY = np.uint16(0xBEEF)
+MAX_ULPS = 4
+VARIANTS = [(0, "3-pass"), (1, "online")]
+SMALL_ROW_KID = 2
+SCRATCH_KID = [0]
+
+
+def f32_to_bf16(x):
+    """float32 array -> raw bf16 bit patterns (uint16), round-to-nearest-even"""
+    u = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    return ((u + np.uint32(0x7FFF) + lsb) >> np.uint32(16)).astype(np.uint16)
+
+
+def bf16_to_fp32(b):
+    return (b.astype(np.uint32) << np.uint32(16)).view(np.float32)
+
+
+def check(dev, golden, label, max_ulps=MAX_ULPS, atol=1e-37):
+    golden = np.asarray(golden, dtype=np.float64)
+    ulp = np.abs(
+        dev.astype(np.int32) - f32_to_bf16(golden.astype(np.float32)).astype(np.int32)
+    )
+    abs_err = np.abs(bf16_to_fp32(dev).astype(np.float64) - golden)
+    over = (ulp > max_ulps) & (abs_err > atol)
+    if over.any():
+        w = int(np.argmax(np.where(over, ulp, -1)))
+        raise AssertionError(
+            f"{label}: {int(ulp[over].max())} ULP > {max_ulps} "
+            f"(dev={float(bf16_to_fp32(dev)[w]):.3e} golden={float(golden[w]):.3e})"
+        )
+    keep = ~((ulp > max_ulps) & (abs_err <= atol))
+    return int(ulp[keep].max()) if keep.any() else 0
+
+
+def softmax_ref(x):
+    xq = bf16_to_fp32(f32_to_bf16(x))
+    e = np.exp((xq - xq.max()).astype(np.float64))
+    return e / e.sum()
+
+
+async def run(fixture, x, kernel_id=0, alias=0, scratch_len=None, repeat=1):
+    n = x.shape[0]
+    pad = 8
+    if scratch_len is None:
+        scratch_len = n
+    await fixture.write("active_n", np.array([n], dtype=np.uint32))
+    await fixture.write("active_scratch_len", np.array([scratch_len], dtype=np.uint32))
+    await fixture.write("kernel_id", np.array([kernel_id], dtype=np.uint32))
+    await fixture.write("alias", np.array([alias], dtype=np.uint32))
+    await fixture.write("repeat", np.array([repeat], dtype=np.uint32))
+    await fixture.write("softmax_in", f32_to_bf16(x))
+    await fixture.write("softmax_out", np.full(n + pad, CANARY, dtype=np.uint16))
+    sim_cycles = await fixture.run_to_halt(timeout_cycles=10_000_000)
+    ok = int((await fixture.read("softmax_ok", 4)).view(np.uint32)[0])
+    out = (await fixture.read("softmax_out", (n + pad) * 2)).view(np.uint16)
+    if repeat >= 1:
+        np.testing.assert_array_equal(out[n:], np.full(pad, CANARY, np.uint16))
+    return ok, out[:n], softmax_ref(x), sim_cycles
+
+
+async def _setup(dut):
+    r = runfiles.Create()
+    fixture = await Fixture.Create(dut, csr_base_addr=CSR_BASE)
+    elf_path = r.Rlocation(ELF)
+    if not elf_path or not os.path.exists(elf_path):
+        raise FileNotFoundError(f"Cound not find ELF at {elf_path}")
+    await fixture.load_elf_and_lookup_symbols(
+        elf_path,
+        [
+            "softmax_in",
+            "softmax_out",
+            "active_n",
+            "active_scratch_len",
+            "kernel_id",
+            "alias",
+            "repeat",
+            "softmax_ok",
+            "cycle_count",
+        ],
+    )
+    await fixture.core_mini_axi.reset()
+    return fixture
+
+
+@cocotb.test()
+async def softmax_bf16_corr_test(dut):
+    fixture = await _setup(dut)
+    rng = np.random.default_rng(seed=13)
+    log = dut._log
+
+    n = 256
+    for kid, name in VARIANTS:
+        worst = 0
+        cases = {
+            "all-equal": np.zeros(n, np.float32),
+            "one-hot": np.concatenate(([30.0], np.zeros(n - 1))).astype(np.float32),
+            "large-mag": rng.uniform(-50.0, 50.0, n).astype(np.float32),
+            "random": rng.uniform(-10.0, 10.0, n).astype(np.float32),
+            "ascending": np.linspace(-10.0, 10.0, n).astype(np.float32),
+        }
+        for cname, x in cases.items():
+            ok, out, golden, _ = await run(fixture, x, kid)
+            assert ok == 1, name
+            worst = max(worst, check(out, golden, cname))
+        for m in [1, 31, 33, 640, 643, 2048]:
+            x = rng.uniform(-10.0, 10.0, m).astype(np.float32)
+            ok, out, golden, _ = await run(fixture, x, kid)
+            assert ok == 1
+            worst = max(worst, check(out, golden, f"n={m}"))
+        x = rng.uniform(-10.0, 10.0, n).astype(np.float32)
+        ok, out, golden, _ = await run(fixture, x, kid, alias=1)
+        assert ok == 1
+        worst = max(worst, check(out, golden, "in-place"))
+        xasc = np.linspace(-10.0, 10.0, 2048).astype(np.float32)
+        ok, out, golden, _ = await run(fixture, xasc, kid)
+        assert ok == 1
+        worst = max(worst, check(out, golden, "asc-2048"))
+        log.info(f"softmax [{name}]: worst {worst} ULP (limit {MAX_ULPS})")
+
+    worst = 0
+    for m in [1, 2, 8, 16, 31, 32]:
+        for x in (
+            rng.uniform(-30.0, 30.0, m).astype(np.float32),
+            np.zeros(m, np.float32),
+            (
+                np.concatenate(([40.0], np.zeros(m - 1))).astype(np.float32)
+                if m > 1
+                else np.array([3.0], np.float32)
+            ),
+        ):
+            ok_s, out_s, golden, _ = await run(fixture, x, SMALL_ROW_KID)
+            assert ok_s == 1, f"small-row refused n={m}"
+            ok_b, out_b, _, _ = await run(fixture, x, 0)
+            np.testing.assert_array_equal(out_s, out_b)
+            worst = max(worst, check(out_s, golden, f"small n={m}"))
+    log.info(f"sofrmax [small-row]: worst {worst} ULP, bit-identical to 3-pass")
+
+    ok_s, out_s, _, _ = await run(
+        fixture, rng.uniform(-10.0, 10.0, n).astype(np.float32), SMALL_ROW_KID
+    )
+    assert ok_s == 0, "small-row must refuse n > VLMAX"
+    np.testing.assert_array_equal(out_s, np.full(n, CANARY, np.uint16))
+    ok_s, out_s, golden, _ = await run(
+        fixture,
+        rng.uniform(-10.0, 10.0, 32).astype(np.float32),
+        SMALL_ROW_KID,
+        scratch_len=0,
+    )
+    assert ok_s == 1, "small-row nust run without scratch"
+    check(out_s, golden, "small-row zero-sratch")
+
+    for kid in SCRATCH_KID:
+        ok, out, _, _ = await run(
+            fixture,
+            rng.uniform(-10.0, 10.0, n).astype(np.float32),
+            0,
+            scratch_len=n - 1,
+        )
+        assert ok == 0, dict(VARIANTS)[kid]
+        np.testing.assert_array_equal(out, np.full(n, CANARY, np.uint16))
+    xz = rng.uniform(-10.0, 10.0, n).astype(np.float32)
+    for kid, name in VARIANTS:
+        ok, out, golden, _ = await run(fixture, xz, kid, scratch_len=0)
+        if kid in SCRATCH_KID:
+            assert ok == 0, name
+            np.testing.assert_array_equal(out, np.full(n, CANARY, np.uint16))
+        else:
+            assert ok == 1, name
+            check(out, golden, name)
+
+
+@cocotb.test()
+async def softmax_bf16_perf_test(dut):
+    fixture = await _setup(dut)
+    rng = np.random.default_rng(seed=13)
+    log = dut._log
+
+    nbig = 4096
+    xb = rng.uniform(-10.0, 10.0, nbig).astype(np.float32)
+    _, _, _, startup = await run(fixture, xb, 0, repeat=0)
+    log.info(f"fixed startup (repeat=0): {startup} cyc")
+    base = None
+    for kid, name in VARIANTS:
+        ok, out, golden, cyc = await run(fixture, xb, kid)
+        assert ok == 1, name
+        w = check(out, golden, name)
+        pc = cyc - startup
+        base = base or pc
+        scratch_b = nbig * 4 if kid in SCRATCH_KID else 0
+        log.info(
+            f"  n={nbig} {name}: raw {cyc} cyc | per-call {pc} "
+            f"({pc / nbig:.2f} cyc/elem, {base / pc:.3f}x, scratch {scratch_b} B, worst {w} ULP)"
+        )
+
+    nsr, reps = 32, 64
+    xs = rng.uniform(-10.0, 10.0, nsr).astype(np.float32)
+    base = None
+    for kid, name in VARIANTS + [(SMALL_ROW_KID, "small-row")]:
+        ok, out, golden, cyc_raw = await run(fixture, xs, kid)
+        assert ok == 1
+        w = check(out, golden, name)
+        _, _, _, cyc = await run(fixture, xs, kid, repeat=reps)
+        pc = (cyc - startup) / reps
+        base = base or pc
+        log.info(
+            f"  n={nsr} {name}: raw {cyc_raw} cyc | per-call {pc:.0f} cyc "
+            f"({pc / nsr:.2f} cyc/elem, {base / pc:.3f}x, worst {w} ULP)"
+        )

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_kernel.cc
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_kernel.cc
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bf16 numerically-stable softmax over a 1-D array, computed in fp32:
+//   m = max(x);  e_j = exp(x_j - m);  y_j = e_j / sum_k e_k.
+// Subtracting the max keeps every exp argument <= 0 (so RvvExpNonPosF32m8's
+// one-sided clamp is valid) and guarantees no overflow.
+// 
+// Three variants:
+// 	- 	SoftmaxBf16			3 passes, needs an fp32 scratch[n]:
+//		(1) max, (2) exp into scratch + accumulate sum, (3) normalize
+//		One exp evaluation per element.
+//	- 	SoftmaxBf16_Online	2 passes, No scratch (flash-attention
+//	  	style): a single fused pass tracks the running max and a 
+//	  	running sum rescaled on the fly, then a second max and a 
+//		exp to normalize. Trades n extra exp evaluations for O(1)
+//		memory; use when scratch is unavailable or n is larhe.
+//	- 	SoftmaxBf16_SmallRow	register-resident, for a short row that 
+//	  	fits in one e32m8 group (n <= VLMAX). The whole row stays in
+//	  	vector registers: 1 load + 1 store, NO scratch, NO re-read, and 
+//    	one integer key-max + one vfredusum for the entire row (no
+//	  	pre-strip reductions). Same math and accuracy as SoftmaxBf16. 
+// 	  	Returns false for n > VLMAX (dispatch to SoftmaxBf16 for long rows).
+//	  	This is the idiom the project's flash-attention kernel uses.
+//
+// Element-wise combines accumulate into full-width vector accumulators (_tu on
+// tail strips) so each kernel does O(1) reductions per call, not one per strip.
+// All max reductions run in the bf16 intefer domain via sihn-magnitude keys;
+// sum reductions stay fp32. Bit-identical across variants
+//
+// Data is raw bf16 (uint16). In-place (out == in) is safe: each strip is read
+// before its store and elements never cross strips
+#include <riscv_vector.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "tests/cocotb/rvv/ml_ops/bf16_activations/rvv_math.h"
+
+extern "C" {
+
+// 3-pass softmax with fp32 scratch. `scratch` must hold >= n floats;
+// if `scratch_len < n` the kernel writes nothing and returns false.
+bool SoftmaxBf16(const uint16_t* in, uint16_t* out, size_t n, float* scratch,
+                size_t scratch_len) {
+	if (n == 0) return true;
+	if (scratch_len < n) return false;
+	const size_t vlmax = __riscv_vsetvlmax_e32m8();
+
+	const size_t n_full = n - (n % vlmax);  // hoisted: loop back-edge is add+bltu
+
+	// Pass 1: max(x) in the bf16 intefer domain at e16m8 (64 bf16/strip, no
+	// widening converts). Sign-magitude keys make intefer order == float order;
+	// bit-identical to an fp32 vfredmax on finite inputs.
+	// PRECONDITION: finite inputsl a NaN would key above + inf
+	const size_t vlmax16 = __riscv_vsetvlmax_e16m8();
+	const size_t n_full16 = n - (n % vlmax16);
+	// key(-inf) = 0x007F, so a zero init sits below every finite key.
+	vuint16m8_t kacc = __riscv_vmv_v_x_u16m8(0, vlmax16);
+	size_t i = 0;
+	for (; i < n_full16; i += vlmax16) {
+		vuint16m8_t x = __riscv_vle16_v_u16m8(in + i, vlmax16);
+		vint16m8_t m = __riscv_vsra_vx_i16m8(
+			__riscv_vreinterpret_v_u16m8_i16m8(x), 15, vlmax16);
+		vuint16m8_t mask = __riscv_vor_vx_u16m8(
+			__riscv_vreinterpret_v_i16m8_u16m8(m), 0x8000, vlmax16);
+		kacc = __riscv_vmaxu_vv_u16m8(kacc, __riscv_vxor_vv_u16m8(x, mask, vlmax16),
+									vlmax16);
+	}
+	if (i < n) {
+		size_t vl = __riscv_vsetvl_e16m8(n - i);
+		vuint16m8_t x = __riscv_vle16_v_u16m8(in + i, vl);
+		vint16m8_t m = __riscv_vsra_vx_i16m8(
+			__riscv_vreinterpret_v_u16m8_i16m8(x), 15, vl);
+		vuint16m8_t mask = __riscv_vor_vx_u16m8(
+			__riscv_vreinterpret_v_i16m8_u16m8(m), 0x8000, vl);
+		kacc = __riscv_vmaxu_vv_u16m8_tu(kacc, kacc,
+										__riscv_vxor_vv_u16m8(x, mask, vl), vl);
+	}
+	// Fold m8 -> m4, reduce, then un-key the winner in scalar
+	const size_t vlmax16m4 = __riscv_vsetvlmax_e16m4();
+	vuint16m4_t k4 = __riscv_vmaxu_vv_u16m4(__riscv_vget_v_u16m8_u16m4(kacc, 0),
+											__riscv_vget_v_u16m8_u16m4(kacc, 1),
+											vlmax16m4);
+	vuint16m1_t kred = __riscv_vredmaxu_vs_u16m4_u16m1(
+		k4, __riscv_vmv_v_x_u16m1(0, 1), vlmax16m4);
+	const uint16_t kmax = __riscv_vmv_x_s_u16m1_u16(kred);
+	const uint16_t bmax =
+		(kmax & 0x8000) ? (uint16_t)(kmax ^ 0x8000) : (uint16_t)~kmax;
+	const uint32_t max_bits = (uint32_t)bmax << 16;
+	float max_val;
+	__builtin_memcpy(&max_val, &max_bits, sizeof(max_val));
+
+	// Pass 2: e = exp(x - max) into scratch, accumulate the sum lane-wise
+	// (constant-vl main loop + one _tu tail)
+	vfloat32m8_t acc_sum = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+	for (i = 0; i < n_full; i += vlmax) {
+		vfloat32m8_t x = RvvLoadBf16AsF32m8(in + i, vlmax);
+		vfloat32m8_t shifted = __riscv_vfsub_vf_f32m8(x, max_val, vlmax);
+		vfloat32m8_t e = RvvExpNonPosF32m8(shifted, vlmax);  // arg <= 0
+		__riscv_vse32_v_f32m8(scratch + i, e, vlmax);
+		acc_sum = __riscv_vfadd_vv_f32m8(acc_sum, e, vlmax);
+	}
+	if (i < n) {
+		size_t vl = __riscv_vsetvl_e32m8(n - i);
+		vfloat32m8_t x = RvvLoadBf16AsF32m8(in + i, vl);
+		vfloat32m8_t shifted = __riscv_vfsub_vf_f32m8(x, max_val, vl);
+		vfloat32m8_t e = RvvExpNonPosF32m8(shifted, vl);
+		__riscv_vse32_v_f32m8(scratch + i, e, vl);
+		acc_sum = __riscv_vfadd_vv_f32m8_tu(acc_sum, acc_sum, e, vl);
+	}
+	// acc_sum is full-width valid (zero-init + _tu tail), so the tree fold is
+	// exact over the same values.
+	const float inv_sum = 1.0f / RvvTreeSumF32m8(acc_sum);
+
+	// Pass 3: normalize (constant-vl main loop + one tail strip)
+	for (i = 0; i < n_full; i += vlmax) {
+		vfloat32m8_t e = __riscv_vle32_v_f32m8(scratch + i, vlmax);
+		RvvStoreF32AsBf16m8(out + i, __riscv_vfmul_vf_f32m8(e, inv_sum, vlmax), vlmax);
+	}
+	if (i < n) {
+		size_t vl = __riscv_vsetvl_e32m8(n - i);
+		vfloat32m8_t e = __riscv_vle32_v_f32m8(scratch + i, vl);
+		RvvStoreF32AsBf16m8(out + i, __riscv_vfmul_vf_f32m8(e, inv_sum, vl), vl);
+	}
+	return true;
+}
+
+
+// online (flash-attention) softmax, no scratch. The `scratch`
+// parameters are accepted for a uniform ABI with kernel_id 0 but unused.
+bool SoftmaxBf16_Online(const uint16_t* in, uint16_t* out, size_t n,
+                       float* scratch, size_t scratch_len) {
+	(void)scratch;
+	(void)scratch_len;
+	if (n == 0) return true;
+	const size_t vlmax = __riscv_vsetvlmax_e32m8();
+
+	// Fused pass: running max `m` (scalar) and running denominator as a vector
+	// accumulator `dv`. When the max grows, the already-accumulated terms are
+	// rescaled by exp(m_old - m_new) via a scalar factor broadcast over dv.
+	float m = -__builtin_inff();
+	uint16_t kmax_run = 0;  // below every finite key; key(-inf) = 0x007F
+	vfloat32m8_t dv = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+	for (size_t i = 0; i < n;) {
+		size_t vl = __riscv_vsetvl_e32m8(n - i);
+		vuint16m4_t raw = __riscv_vle16_v_u16m4(in + i, vl);
+		// Chunk max as an integer key; the running max is compared as a key and 
+		// un-keyed only when it grows. Bit-identical to the fp32 path
+		const uint16_t kchunk =
+		RvvBf16MaxKeyReduceSeededM4(RvvBf16MaxKeyM4(raw, vl), kmax_run, vl);
+		if (kchunk > kmax_run) {
+		const float chunk_max = Bf16BitsToF32(RvvBf16UnKey(kchunk));
+		const float corr = ScalarExpNonPosF32(m - chunk_max);  // m-chunk_max <= 0
+		dv = __riscv_vfmul_vf_f32m8(dv, corr, vlmax);
+		m = chunk_max;
+		kmax_run = kchunk;
+		}
+		vfloat32m8_t x = RvvWidenBf16ToF32m8(raw, vl);
+		vfloat32m8_t shifted = __riscv_vfsub_vf_f32m8(x, m, vl);
+		vfloat32m8_t e = RvvExpNonPosF32m8(shifted, vl);  // arg <= 0
+		dv = __riscv_vfadd_vv_f32m8_tu(dv, dv, e, vl);
+		i += vl;
+	}
+	// dv is full-width valid (zero-init, full-lane rescales, _tu adds).
+	const float inv = 1.0f / RvvTreeSumF32m8(dv);
+
+	// Normalizing pass: recompute exp(x - m) and scale.
+	for (size_t i = 0; i < n;) {
+		size_t vl = __riscv_vsetvl_e32m8(n - i);
+		vfloat32m8_t x = RvvLoadBf16AsF32m8(in + i, vl);
+		vfloat32m8_t shifted = __riscv_vfsub_vf_f32m8(x, m, vl);
+		vfloat32m8_t e = RvvExpNonPosF32m8(shifted, vl);
+		vfloat32m8_t y = __riscv_vfmul_vf_f32m8(e, inv, vl);
+		RvvStoreF32AsBf16m8(out + i, y, vl);
+		i += vl;
+	}
+	return true;
+}
+
+// register-resident softmax for a short row that fits one e32m8 group (n <= VLMAX).
+// The whole row staysin registers: one load, one store, no scratch, no re-read, 
+// one key-max + one vfredusum. Numerically identical to SoftmaxBf16. Returns 
+// false for n > VLMAX. The `scratch` parameters are accepted for a uniform ABI 
+// with kernel_id 0 but unused.
+bool SoftmaxBf16_SmallRow(const uint16_t* in, uint16_t* out, size_t n,
+                          float* scratch, size_t scratch_len) {
+	(void)scratch;
+	(void)scratch_len;
+	if (n == 0) return true;
+	const size_t vlmax = __riscv_vsetvlmax_e32m8();
+	if (n > vlmax) return false;                        // row must fit in one group
+	size_t vl = __riscv_vsetvl_e32m8(n);
+	vuint16m4_t raw = __riscv_vle16_v_u16m4(in, vl);    // single load, stays resident
+	// Max over the whole row via integer keys (bit-identical to SoftmaxBf16)
+	const uint16_t kmax = RvvBf16MaxKeyReduceM4(RvvBf16MaxKeyM4(raw, vl), vl);
+	const float m = Bf16BitsToF32(RvvBf16UnKey(kmax));
+	vfloat32m8_t x = RvvWidenBf16ToF32m8(raw, vl);
+	// exp(x - m), entirely in registers (arg <= 0)
+	vfloat32m8_t e = RvvExpNonPosF32m8(__riscv_vfsub_vf_f32m8(x, m, vl), vl);
+	// Sum via the same tree fold as kid0 (bit-identity contract). e's tail
+	// lanes are garbage, so copy the active lanes over a zero background first
+	// (e >= +0, so e + 0.0 is bit-exact); the result equals kid0's acc_sum
+	// for the same n lane-for-lane, so the identical fold gives identical bits.
+	vfloat32m8_t sacc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+	sacc = __riscv_vfadd_vf_f32m8_tu(sacc, e, 0.0f, vl);
+	const float inv = 1.0f / RvvTreeSumF32m8(sacc);
+	// normalize in registers, single store
+	RvvStoreF32AsBf16m8(out, __riscv_vfmul_vf_f32m8(e, inv, vl), vl);
+	return true;
+}
+
+}  // extern "C"

--- a/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_runner.cc
+++ b/tests/cocotb/rvv/ml_ops/bf16_activations/softmax_bf16_runner.cc
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" bool SoftmaxBf16(const uint16_t *in, uint16_t *out, int n, float *scratch, int scratch_len);
+extern "C" bool SoftmaxBf16_Online(const uint16_t *in, uint16_t *out, int n, float *scratch, int scratch_len);
+extern "C" bool SoftmaxBf16_SmallRow(const uint16_t* in, uint16_t* out, size_t n, float* scratch, size_t scratch_len);
+
+#define MAX_N 8192
+#define EXTMEM __attribute__((section(".extmem"))) __attribute__((aligned(16)))
+
+extern "C" {
+uint16_t softmax_in[MAX_N] EXTMEM;
+uint16_t softmax_out[MAX_N] EXTMEM;
+uint32_t active_n EXTMEM = 256;
+uint32_t active_scratch_len EXTMEM = MAX_N;
+uint32_t kernel_id  EXTMEM = 0;             // 0: 3-pass, 1: online, 2: small-row
+uint32_t alias  EXTMEM = 0;                 // 1: test in-place (in == out)
+uint32_t softmax_ok EXTMEM = 0;             // kernel bool return
+uint32_t repeat EXTMEM = 0;
+uint32_t cycle_count EXTMEM = 0;
+}
+
+// fp32 scratch for the 3-pass kernel
+static float softmax_scratch[MAX_N] __attribute__((section(".noinit")));
+
+int main() {
+    if (active_n > MAX_N) return -1;
+    const int n  = static_cast<int>(active_n);
+    const size_t slen = static_cast<size_t>(active_scratch_len);
+    const uint16_t* in_ptr = softmax_in;
+    if (alias != 0) {
+        for (int i = 0; i < n; ++i) softmax_out[i] = softmax_in[i];
+        in_ptr = softmax_out;
+    }
+
+    uint32_t start;
+    asm volatile("csrr %0, mcycle" : "=r"(start) : : "memory");
+
+    bool ok = true;
+    for (uint32_t r = 0; r < repeat; ++r) {
+        switch (kernel_id) {
+            case 1:     ok = SoftmaxBf16_Online(in_ptr, softmax_out, n, 
+                                    softmax_scratch, slen);  break;
+            case 2:     ok = SoftmaxBf16_SmallRow(in_ptr, softmax_out, n, 
+                                    softmax_scratch, slen);  break;
+            default:    ok = SoftmaxBf16(in_ptr, softmax_out, n, 
+                                    softmax_scratch, slen);  break;
+        }
+    }
+    softmax_ok = ok ? 1u : 0u;
+    
+    uint32_t end;
+    asm volatile("csrr %0, mcycle" : "=r"(end) : : "memory");
+    cycle_count = end - start;
+    return 0;
+}


### PR DESCRIPTION
Add bf16 kernel implementations for `sigmoid` and `softmax` activations optimized for RISC-V Vector (RVV) extensions. 

Implemented `sigmoid_bf16_kernel.cc` and `softmax_bf16_kernel.cc` that load/store bf16 while performing intermediate vector math in fp32. 

Added `rvv_math.h` with shared helper functions, including an optimized vector `exp` approximation and `bf16 <-> fp32` conversion routines. It supports both native `Zvfbfmin` extension and an integer-based fallback for standard `Zve32f` cores.

**Sigmoid Variants:** Provided multiple implementations for Sigmoid (`vfrdiv`, `vfrec7`, and `vfrec7_raw`) to allow trade-offs between precision and speed.

**Softmax Variants:** Provided multiple implementations for Softmax (`SoftmaxBf16`, `SoftmaxBf16_Online`, and `SoftmaxBf16_SmallRow`) to accommodate memory constraints and row sizes.
 
**Test:** Added C++ runners (`*_runner.cc`) and Cocotb-based Python tests (`*_cocotb_test.py`) to validate the underlying math, and kernel correctness and performance.
 
**Build:** Updated the `BUILD` file to include the new targets.