### PR TITLE
Fix ELF path in core_mini_axi_wrapper_example

### DIFF
--- a/hw_sim/core_mini_axi_wrapper_example.cc
+++ b/hw_sim/core_mini_axi_wrapper_example.cc
@@ -29,7 +29,7 @@ int main() {
   wrapper.Reset();
 
   // Load elf
-  auto file_name = "../tests/cocotb/wfi_slot_0.elf";
+  auto file_name = "tests/cocotb/wfi_slot_0.elf";
   int fd = open(file_name, 0);
   if (fd < 0) {
     return -1;


### PR DESCRIPTION
`core_mini_axi_wrapper_example` opens `../tests/cocotb/wfi_slot_0.elf`. Under
`bazel run` the working directory is the runfiles root, where the
`//tests/cocotb:wfi_slot_0.elf` data dependency resolves to
`tests/cocotb/wfi_slot_0.elf`. The leading `../` leaves that root, so `open`
fails and `main` returns -1 before loading the ELF or stepping the design.

`core_mini_axi_simulator_example.cc:30` already uses the runfiles-root-relative
form.

Before:

    $ bazel run //hw_sim:core_mini_axi_wrapper_example
    $ echo $?
    255

After:

    $ bazel run //hw_sim:core_mini_axi_wrapper_example
    Loaded tests/cocotb/wfi_slot_0.elf
    Halted
    $ echo $?
    0
